### PR TITLE
More graceful processing of absent R install

### DIFF
--- a/RInterop.fs
+++ b/RInterop.fs
@@ -65,24 +65,7 @@ module internal RInteropInternal =
     [<Literal>] 
     let RDateOffset = 25569.
 
-    open Microsoft.Win32
-
     let characterDevice = new CharacterDeviceInterceptor()
-
-    // If the registry is set up, use that for configuring the path
-    let rCore = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\R-core")
-    if rCore <> null then
-        let is64bit = Environment.Is64BitProcess
-        let subKeyName = if is64bit then "R64" else "R"
-        let key = rCore.OpenSubKey(subKeyName)
-        if key = null then
-            failwithf "SOFTWARE\R-core exists but subkey %s does not exist" subKeyName
-
-        let installPath = key.GetValue("InstallPath") :?> string
-        let binPath = Path.Combine(installPath, "bin", if is64bit then "x64" else "i386")
-
-        // Set the path
-        Environment.SetEnvironmentVariable("PATH", Environment.GetEnvironmentVariable("PATH") + ";" + binPath)
 
     let engine = 
         try

--- a/RProvider.fs
+++ b/RProvider.fs
@@ -11,10 +11,33 @@ open Microsoft.FSharp.Core.CompilerServices
 open RDotNet
 open RInteropInternal
 open RInterop
+open Microsoft.Win32
 
 [<TypeProvider>]
 type public RProvider(cfg:TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces()
+
+    // R potentially may be not installed - handle this in static constructor for improved diag (G.B.)
+    static do
+        // If the registry is set up, use that for configuring the path
+        let rCore =
+            match Registry.LocalMachine.OpenSubKey(@"SOFTWARE\R-core"), Registry.CurrentUser.OpenSubKey(@"SOFTWARE\R-core") with
+            | null, null -> failwithf "Reg key Software\R-core does not exist; R is likely not installed on this computer"
+            | null, x -> x
+            | x, null -> x
+            | _ as x, _ -> x
+            
+        let is64bit = Environment.Is64BitProcess
+        let subKeyName = if is64bit then "R64" else "R"
+        let key = rCore.OpenSubKey(subKeyName)
+        if key = null then
+            failwithf "SOFTWARE\R-core exists but subkey %s does not exist" subKeyName
+
+        let installPath = key.GetValue("InstallPath") :?> string
+        let binPath = Path.Combine(installPath, "bin", if is64bit then "x64" else "i386")
+
+        // Set the path
+        Environment.SetEnvironmentVariable("PATH", Environment.GetEnvironmentVariable("PATH") + ";" + binPath)
 
     // Get the assembly and namespace used to house the provided types
     let asm = System.Reflection.Assembly.GetExecutingAssembly()


### PR DESCRIPTION
The proposed change addresses two issues related to collocated R installation.
1. If R is not installed or installed by non-administrator, then conditional expression in line 74 of RInterop.fs is false and lines 75 - 85 are skipped. Exception thrown in line 93 is intercepted by fsc as internal producing quite obscure error message "The type initializer for 'RProvider.RInteropInternal' threw an exception". The proposed change moves R installation discovery code into static constructor within RProvider.fs, which in case of absent R install gives very explicit error message "The type provider constructor has thrown an exception: Reg key Software\R-core does not exist; R is likely not installed on this computer"
2. When R installation on a computer was performed using non-administrative account correspondent registry changes end up in 'CurrentUser' hive. The proposed change extends R installation search to cover both 'LocalMachine' and 'CurrentUser' hives.
