### PR TITLE
Code to make the type provider work in Linux

### DIFF
--- a/src/RProvider/RInit.fs
+++ b/src/RProvider/RInit.fs
@@ -70,7 +70,6 @@ let private setupPathVariable () =
               // Set the path
               let pathsepchar = if islinux then ":" else ";"
               Environment.SetEnvironmentVariable("PATH", Environment.GetEnvironmentVariable("PATH") + pathsepchar + binPath)
-              printfn "found R"
               Logging.logf "setupPathVariable completed"
               RInitResult ()
     with e ->


### PR DESCRIPTION
Most of the effort has gone into differences with paths.

What works:

```
    export R_HOME=/lib/R
    fsharpi
```

TODO:
        Use `which` to find R when R_HOME not set
        There appear to be some problems when using fsharpc
