### PR TITLE
Concurrency fixes

### DIFF
--- a/src/RProvider/RInit.fs
+++ b/src/RProvider/RInit.fs
@@ -83,12 +83,12 @@ let characterDevice = new CharacterDeviceInterceptor()
 
 /// Lazily initialized value that, when evaluated, sets the PATH variable
 /// to include the R location, or fails and returns RInitError
-let initResult = Lazy<_>.Create(fun () -> setupPathVariable())
+let initResult = Lazy<_>(fun () -> setupPathVariable())
 
 /// Lazily initialized R engine. When 'DisableStackChecking' has been set prior
 /// to the initialization (in the static constructor of RProvider), then 
 /// set the 'R_CStackLimit' variable to -1.
-let engine = Lazy<_>.Create(fun () ->
+let engine = Lazy<_>(fun () ->
     try
         Logging.logf "engine: Creating instance" 
         initResult.Force() |> ignore

--- a/src/RProvider/RInterop.fs
+++ b/src/RProvider/RInterop.fs
@@ -33,6 +33,9 @@ module Helpers =
     let namedParams (s: seq<string*_>) = dict <| Seq.map (fun (n,v) -> n, box v) s
 
 module internal RInteropInternal =
+    let RSafe f =
+        lock engine f
+
     type RParameter = string
     type HasVarArgs = bool
 
@@ -102,6 +105,7 @@ module internal RInteropInternal =
         | None -> failwithf "No converter registered for type %s or any of its base types" concreteType.FullName
         
     let internal convertFromRBuiltins<'outType> (sexp: SymbolicExpression) : Option<'outType> = 
+        RSafe <| fun () ->
         let retype (x: 'b) : Option<'a> = x |> box |> unbox |> Some
         let at = typeof<'outType>
         match sexp with
@@ -140,6 +144,7 @@ module internal RInteropInternal =
         | _                                                 -> None
 
     let internal convertFromR<'outType> (sexp: SymbolicExpression) : 'outType = 
+        RSafe <| fun () ->
         let concreteType = typeof<'outType>
         let vt = typeof<IConvertFromR<'outType>>
 
@@ -168,6 +173,7 @@ module internal RInteropInternal =
         | _ ->                      None
 
     let internal defaultConvertFromR (sexp: SymbolicExpression) : obj =
+        RSafe <| fun () ->
         let converters = mefContainer.Value.GetExports<IDefaultConvertFromR>()
         match converters |> Seq.tryPick (fun conv -> conv.Value.Convert sexp) with
         | Some res  -> res
@@ -177,11 +183,13 @@ module internal RInteropInternal =
         
 
     let createDateVector (dv: seq<DateTime>) = 
+        RSafe <| fun () ->
         let vec = engine.Value.CreateNumericVector [| for x in dv -> x.ToOADate() - RDateOffset |]
         vec.SetAttribute("class", engine.Value.CreateCharacterVector [|"Date"|])
         vec
 
     do
+        RSafe <| fun () ->
         registerToR<SymbolicExpression> (fun engine v -> v)
 
         registerToR<string>  (fun engine v -> upcast engine.CreateCharacterVector [|v|])
@@ -209,6 +217,7 @@ module internal RInteropInternal =
 
     type RDotNet.REngine with
         member this.SetValue(value: obj, ?symbolName: string) : SymbolicExpression =            
+            RSafe <| fun () ->
             let se = convertToR this value
             if symbolName.IsSome then engine.Value.SetSymbol(symbolName.Value, se)
             se
@@ -218,10 +227,12 @@ module internal RInteropInternal =
 
     /// Get next symbol name
     let getNextSymbolName() : string =
+        RSafe <| fun () ->
         symbolNum <- symbolNum + 1
         sprintf "fsr_%d_%d" pid symbolNum
     
     let toR (value: obj) =
+        RSafe <| fun () ->
         let symbolName = getNextSymbolName()
         let se = engine.Value.SetValue(value, symbolName)
         symbolName, se
@@ -229,16 +240,19 @@ module internal RInteropInternal =
     let makeSafeName (name: string) = name.Replace("_","__").Replace(".", "_")
 
     let eval (expr: string) = 
+        RSafe <| fun () ->
         Logging.logWithOutput characterDevice (fun () ->
             Logging.logf "eval(%s)" expr
             engine.Value.Evaluate(expr) )
 
     let evalTo (expr: string) (symbol: string) = 
+        RSafe <| fun () ->
         Logging.logWithOutput characterDevice (fun () ->
             Logging.logf "evalto(%s, %s)" expr symbol
             engine.Value.SetSymbol(symbol, engine.Value.Evaluate(expr)) )
     
     let exec (expr: string) : unit = 
+        RSafe <| fun () ->
         Logging.logWithOutput characterDevice (fun () ->
             Logging.logf "exec(%s)" expr 
             use res = engine.Value.Evaluate(expr) in () )
@@ -256,6 +270,7 @@ module RDotNetExtensions =
 
 module RInterop =
     let internal bindingInfo (name: string) : RValue = 
+        RSafe <| fun () ->
         Logging.logf "Getting bindingInfo: %s" name
         match eval("typeof(get(\"" + name + "\"))").GetValue() with
         | "closure" ->
@@ -286,12 +301,14 @@ module RInterop =
         eval("packageDescription(\"" + packageName + "\")$Description").GetValue()
 
     let internal getFunctionDescriptions packageName : Map<string, string> =
+        RSafe <| fun () ->
         exec <| sprintf """rds = readRDS(system.file("Meta", "Rd.rds", package = "%s"))""" packageName
         Map.ofArray <| Array.zip ((eval "rds$Name").GetValue()) ((eval "rds$Title").GetValue())
 
     let private packages = System.Collections.Generic.HashSet<string>()
 
     let internal loadPackage packageName : unit =
+        RSafe <| fun () ->
         if not(packages.Contains packageName) then
             if not(eval("require(" + packageName + ")").GetValue()) then
                 failwithf "Loading package %s failed" packageName
@@ -299,6 +316,7 @@ module RInterop =
 
     let internal getBindings packageName : Map<string, RValue> =
         // TODO: Maybe get these from the environments?
+        RSafe <| fun () ->
         let names = eval(sprintf """ls("package:%s")""" packageName).GetValue()
         names
         |> Array.map (fun name -> name, bindingInfo name)
@@ -308,6 +326,7 @@ module RInterop =
             // We make sure we keep a reference to any temporary symbols until after exec is called, 
             // so that the binding is kept alive in R
             // TODO: We need to figure out how to unset the symvol
+            RSafe <| fun () ->
             let tempSymbols = System.Collections.Generic.List<string * SymbolicExpression>()
             let passArg (arg: obj) : string = 
                 match arg with
@@ -362,6 +381,7 @@ module RInterop =
     let call (packageName: string) (funcName: string) (serializedRVal:string) (namedArgs: obj[]) (varArgs: obj[]) : SymbolicExpression =
         //loadPackage packageName
 
+        RSafe <| fun () ->
         match deserializeRValue serializedRVal with
         | RValue.Function(rparams, hasVarArg) ->
             let argNames = rparams

--- a/src/RProvider/RProvider.fs
+++ b/src/RProvider/RProvider.fs
@@ -108,7 +108,7 @@ type public RProvider(cfg:TypeProviderConfig) as this =
     /// Check if R is installed - if no, generate type with properties displaying
     /// the error message, otherwise go ahead and use 'generateTypes'!
     let initAndGenerate () =
-
+        RSafe <| fun () ->
         // Get the assembly and namespace used to house the provided types
         Logging.logf "initAndGenerate: starting"
         let asm = System.Reflection.Assembly.GetExecutingAssembly()

--- a/tests/Test.RProvider/Test.RProvider.fsproj
+++ b/tests/Test.RProvider/Test.RProvider.fsproj
@@ -41,14 +41,15 @@
   <ItemGroup>
     <Compile Include="Test.fs" />
     <None Include="packages.config" />
+    <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsCheck">
-      <HintPath>..\..\packages\FsCheck.0.9.1.0\lib\net40-Client\FsCheck.dll</HintPath>
+      <HintPath>..\..\packages\FsCheck.0.9.2.0\lib\net40-Client\FsCheck.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsCheck.Xunit">
-      <HintPath>..\..\packages\FsCheck.Xunit.0.4.0.1\lib\net40-Client\FsCheck.Xunit.dll</HintPath>
+      <HintPath>..\..\packages\FsCheck.Xunit.0.4.0.2\lib\net40-Client\FsCheck.Xunit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />

--- a/tests/Test.RProvider/app.config
+++ b/tests/Test.RProvider/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/Test.RProvider/packages.config
+++ b/tests/Test.RProvider/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsCheck" version="0.9.1.0" targetFramework="net45" />
-  <package id="FsCheck.Xunit" version="0.4.0.1" targetFramework="net45" />
+  <package id="FsCheck" version="0.9.2.0" targetFramework="net45" />
+  <package id="FsCheck.Xunit" version="0.4.0.2" targetFramework="net45" />
   <package id="R.NET" version="1.5.5" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Protect all access to RDotNet through RInterop using a lock on
RInit.engine. IDE stability issues, apparent parsing errors, and system
access errors are resolved by ensuring that the R environment through
RDotNet is accessed in a thread-safe manner.
