### PR TITLE
Prototype of a type provider for type-safe RData access (#59)

### DIFF
--- a/RProvider.sln
+++ b/RProvider.sln
@@ -47,6 +47,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "RWrapperGenerator", "src\RW
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "RProvider.Runtime", "src\RProvider\RProvider.Runtime.fsproj", "{7FF9CFA3-2516-4970-9DD8-54C7D4CA24AA}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "RDataProvider", "src\RDataProvider\RDataProvider.fsproj", "{56FFD489-CA6D-4BB4-A5C2-9C74D9F4D087}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{7FF9CFA3-2516-4970-9DD8-54C7D4CA24AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7FF9CFA3-2516-4970-9DD8-54C7D4CA24AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7FF9CFA3-2516-4970-9DD8-54C7D4CA24AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56FFD489-CA6D-4BB4-A5C2-9C74D9F4D087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56FFD489-CA6D-4BB4-A5C2-9C74D9F4D087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56FFD489-CA6D-4BB4-A5C2-9C74D9F4D087}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56FFD489-CA6D-4BB4-A5C2-9C74D9F4D087}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/nuget/RProvider.nuspec
+++ b/nuget/RProvider.nuspec
@@ -11,7 +11,7 @@
     <summary>@summary@</summary>
     <description>@description@</description>
     <releaseNotes>@releaseNotes@</releaseNotes>
-    <copyright>Copyright 2013</copyright>
+    <copyright>Copyright 2014</copyright>
     <tags>@tags@</tags>
     <language>en-US</language>
     <dependencies>

--- a/src/Common/ProvidedTypes-0.2.fs
+++ b/src/Common/ProvidedTypes-0.2.fs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation 2005-2012.
+// Copyright (c) Microsoft Corporation 2005-2012.
 // This sample code is provided "as is" without warranty of any kind. 
 // We disclaim all warranties, either express or implied, including the 
 // warranties of merchantability and fitness for a particular purpose. 
@@ -6,9 +6,9 @@
 // This file contains a set of helper types and methods for providing types in an implementation 
 // of ITypeProvider.
 //
-// This code is a sample for use in conjunction with the F# 3.0 Developer Preview release of September 2011.
+// This code is a sample for use in conjunction with the F# 3.0 Beta release of March 2012
 
-namespace Samples.FSharp.ProvidedTypes
+namespace ProviderImplementation.ProvidedTypes
 
 open System
 open System.Text
@@ -19,53 +19,105 @@ open System.Linq.Expressions
 open System.Collections.Generic
 open Microsoft.FSharp.Core.CompilerServices
 
+type internal ExpectedStackState = 
+    | Empty = 1
+    | Address = 2
+    | Value = 3
+
 [<AutoOpen>]
-module Misc =
+module internal Misc =
+    let TypeBuilderInstantiationType = typeof<TypeBuilder>.Assembly.GetType("System.Reflection.Emit.TypeBuilderInstantiation")
+    let GetTypeFromHandleMethod = typeof<Type>.GetMethod("GetTypeFromHandle")
+    let LanguagePrimitivesType = typedefof<list<_>>.Assembly.GetType("Microsoft.FSharp.Core.LanguagePrimitives")
+    let ParseInt32Method = LanguagePrimitivesType.GetMethod "ParseInt32"
+    let isEmpty s = s = ExpectedStackState.Empty
+    let isAddress s = s = ExpectedStackState.Address
+
     let nonNull str x = if x=null then failwith ("Null in " + str) else x
+    
     let notRequired opname item = 
         let msg = sprintf "The operation '%s' on item '%s' should not be called on provided type, member or parameter" opname item
         System.Diagnostics.Debug.Assert (false, msg)
         raise (System.NotSupportedException msg)
 
-    let mkEditorHideMethodsCustomAttributeData() = 
+    let mkParamArrayCustomAttributeData() = 
+#if FX_NO_CUSTOMATTRIBUTEDATA
+        { new IProvidedCustomAttributeData with 
+#else
         { new CustomAttributeData() with 
-                member __.Constructor =  typeof<TypeProviderEditorHideMethodsAttribute>.GetConstructors().[0]
-                member __.ConstructorArguments = upcast [| |]
-                member __.NamedArguments = upcast [| |] }
+#endif 
+            member __.Constructor =  typeof<ParamArrayAttribute>.GetConstructors().[0]
+            member __.ConstructorArguments = upcast [| |]
+            member __.NamedArguments = upcast [| |] }
+
+#if FX_NO_CUSTOMATTRIBUTEDATA
+    let CustomAttributeTypedArgument(ty,v) = 
+        { new IProvidedCustomAttributeTypedArgument with 
+              member x.ArgumentType = ty
+              member x.Value = v }
+    let CustomAttributeNamedArgument(memb,arg:IProvidedCustomAttributeTypedArgument) = 
+        { new IProvidedCustomAttributeNamedArgument with 
+              member x.MemberInfo = memb
+              member x.ArgumentType = arg.ArgumentType
+              member x.TypedValue = arg }
+    type CustomAttributeData = Microsoft.FSharp.Core.CompilerServices.IProvidedCustomAttributeData
+#endif
+
+    let mkEditorHideMethodsCustomAttributeData() = 
+#if FX_NO_CUSTOMATTRIBUTEDATA
+        { new IProvidedCustomAttributeData with 
+#else
+        { new CustomAttributeData() with 
+#endif 
+            member __.Constructor =  typeof<TypeProviderEditorHideMethodsAttribute>.GetConstructors().[0]
+            member __.ConstructorArguments = upcast [| |]
+            member __.NamedArguments = upcast [| |] }
 
     /// This makes an xml doc attribute w.r.t. an amortized computation of an xml doc string.
     /// It is important that the text of the xml doc only get forced when poking on the ConstructorArguments
     /// for the CustomAttributeData object.
     let mkXmlDocCustomAttributeDataLazy(lazyText: Lazy<string>) = 
+#if FX_NO_CUSTOMATTRIBUTEDATA
+        { new IProvidedCustomAttributeData with 
+#else
         { new CustomAttributeData() with 
-                member __.Constructor =  typeof<TypeProviderXmlDocAttribute>.GetConstructors().[0]
-                member __.ConstructorArguments = upcast [| CustomAttributeTypedArgument(typeof<string>, lazyText.Force())  |]
-                member __.NamedArguments = upcast [| |] }
+#endif
+            member __.Constructor =  typeof<TypeProviderXmlDocAttribute>.GetConstructors().[0]
+            member __.ConstructorArguments = upcast [| CustomAttributeTypedArgument(typeof<string>, lazyText.Force())  |]
+            member __.NamedArguments = upcast [| |] }
 
     let mkXmlDocCustomAttributeData(s:string) =  mkXmlDocCustomAttributeDataLazy (lazy s)
 
     let mkDefinitionLocationAttributeCustomAttributeData(line:int,column:int,filePath:string) = 
+#if FX_NO_CUSTOMATTRIBUTEDATA
+        { new IProvidedCustomAttributeData with 
+#else
         { new CustomAttributeData() with 
-                member __.Constructor =  typeof<TypeProviderDefinitionLocationAttribute>.GetConstructors().[0]
-                member __.ConstructorArguments = upcast [| |]
-                member __.NamedArguments = 
-                    upcast [| CustomAttributeNamedArgument(typeof<TypeProviderDefinitionLocationAttribute>.GetProperty("FilePath"), CustomAttributeTypedArgument(typeof<string>, filePath));
-                              CustomAttributeNamedArgument(typeof<TypeProviderDefinitionLocationAttribute>.GetProperty("Line"), CustomAttributeTypedArgument(typeof<int>, line)) ;
-                              CustomAttributeNamedArgument(typeof<TypeProviderDefinitionLocationAttribute>.GetProperty("Column"), CustomAttributeTypedArgument(typeof<int>, column)) 
-                           |] }
-    
-    let mkParamArrayCustomAttributeData() =
-        { new CustomAttributeData() with
-                member __.Constructor = typeof<ParamArrayAttribute>.GetConstructors().[0]
-                member __.ConstructorArguments = upcast [| |]
-                member __.NamedArguments = upcast [| |]
-        }
+#endif
+            member __.Constructor =  typeof<TypeProviderDefinitionLocationAttribute>.GetConstructors().[0]
+            member __.ConstructorArguments = upcast [| |]
+            member __.NamedArguments = 
+                upcast [| CustomAttributeNamedArgument(typeof<TypeProviderDefinitionLocationAttribute>.GetProperty("FilePath"), CustomAttributeTypedArgument(typeof<string>, filePath));
+                            CustomAttributeNamedArgument(typeof<TypeProviderDefinitionLocationAttribute>.GetProperty("Line"), CustomAttributeTypedArgument(typeof<int>, line)) ;
+                            CustomAttributeNamedArgument(typeof<TypeProviderDefinitionLocationAttribute>.GetProperty("Column"), CustomAttributeTypedArgument(typeof<int>, column)) 
+                        |] }
+    let mkObsoleteAttributeCustomAttributeData(message:string, isError: bool) = 
+#if FX_NO_CUSTOMATTRIBUTEDATA
+        { new IProvidedCustomAttributeData with 
+#else
+        { new CustomAttributeData() with 
+#endif
+                member __.Constructor =  typeof<System.ObsoleteAttribute>.GetConstructors() |> Array.find (fun x -> x.GetParameters().Length = 1)
+                member __.ConstructorArguments = upcast [|CustomAttributeTypedArgument(typeof<string>, message) ; CustomAttributeTypedArgument(typeof<bool>, isError)  |]
+                member __.NamedArguments = upcast [| |] }
 
     type CustomAttributesImpl() =
         let customAttributes = ResizeArray<CustomAttributeData>()
         let mutable hideObjectMethods = false
+        let mutable obsoleteMessage = None
         let mutable xmlDocDelayed = None
         let mutable xmlDocAlwaysRecomputed = None
+        let mutable hasParamArray = false
 
         // XML doc text that we only compute once, if any. This must _not_ be forced until the ConstructorArguments
         // property of the custom attribute is foced.
@@ -78,12 +130,15 @@ module Misc =
             lazy 
                [| if hideObjectMethods then yield mkEditorHideMethodsCustomAttributeData() 
                   match xmlDocDelayed with None -> () | Some _ -> customAttributes.Add(mkXmlDocCustomAttributeDataLazy xmlDocDelayedText) 
+                  match obsoleteMessage with None -> () | Some s -> customAttributes.Add(mkObsoleteAttributeCustomAttributeData s) 
+                  if hasParamArray then yield mkParamArrayCustomAttributeData()
                   yield! customAttributes |]
 
         member __.AddDefinitionLocation(line:int,column:int,filePath:string) = customAttributes.Add(mkDefinitionLocationAttributeCustomAttributeData(line, column, filePath))
+        member __.AddObsolete(msg : string, isError) = obsoleteMessage <- Some (msg,isError)
+        member __.HasParamArray with get() = hasParamArray and set(v) = hasParamArray <- v
         member __.AddXmlDocComputed(xmlDoc : unit -> string) = xmlDocAlwaysRecomputed <- Some xmlDoc
         member __.AddXmlDocDelayed(xmlDoc : unit -> string) = xmlDocDelayed <- Some xmlDoc
-        member __.AddParamArray() = customAttributes.Add(mkParamArrayCustomAttributeData())
         member this.AddXmlDoc(text:string) =  this.AddXmlDocDelayed (fun () -> text)
         member __.HideObjectMethods with set v = hideObjectMethods <- v
         member __.GetCustomAttributesData() = 
@@ -91,11 +146,36 @@ module Misc =
                match xmlDocAlwaysRecomputed with None -> () | Some f -> customAttributes.Add(mkXmlDocCustomAttributeData (f()))  |]
             :> IList<_>
 
-
-    let transQuotationToCode qexprf (argExprs: Quotations.Expr[]) = 
-        let expr = qexprf (Array.toList argExprs)
+    let transExpr isGenerated q =     
         let rec trans q = 
             match q with 
+            // convert NewTuple to the call to the constructor of the Tuple type (only for generated types)
+            | Quotations.Patterns.NewTuple(items) when isGenerated ->
+                let rec mkCtor args ty = 
+                    let ctor, restTyOpt = Reflection.FSharpValue.PreComputeTupleConstructorInfo ty
+                    match restTyOpt with
+                    | None -> Quotations.Expr.NewObject(ctor, List.map trans args)
+                    | Some restTy ->
+                        let curr = [for a in Seq.take 7 args -> trans a]
+                        let rest = List.ofSeq (Seq.skip 7 args) 
+                        Quotations.Expr.NewObject(ctor, curr @ [mkCtor rest restTy])
+                let tys = [| for e in items -> e.Type |]
+                let tupleTy = Reflection.FSharpType.MakeTupleType tys
+                trans (mkCtor items tupleTy)
+            // convert TupleGet to the chain of PropertyGet calls (only for generated types)
+            | Quotations.Patterns.TupleGet(e, i) when isGenerated ->
+                let rec mkGet ty i (e : Quotations.Expr)  = 
+                    let pi, restOpt = Reflection.FSharpValue.PreComputeTuplePropertyInfo(ty, i)
+                    let propGet = Quotations.Expr.PropertyGet(e, pi)
+                    match restOpt with
+                    | None -> propGet
+                    | Some (restTy, restI) -> mkGet restTy restI propGet
+                trans (mkGet e.Type i (trans e))
+            | Quotations.Patterns.Value(value, ty) ->
+                if value <> null then
+                   let tyOfValue = value.GetType()
+                   transValue(value, tyOfValue, ty)
+                else q
             // Eliminate F# property gets to method calls
             | Quotations.Patterns.PropertyGet(obj,propInfo,args) -> 
                 match obj with 
@@ -126,13 +206,82 @@ module Misc =
                 let tagNumber = uc.Tag
                 trans <@@ (%%(tagExpr) : int) = tagNumber @@>
 
+            // Explicitly handle weird byref variables in lets (used to populate out parameters), since the generic handlers can't deal with byrefs
+            | Quotations.Patterns.Let(v,vexpr,bexpr) when v.Type.IsByRef ->
+
+                // the binding must have leaves that are themselves variables (due to the limited support for byrefs in expressions)
+                // therefore, we can perform inlining to translate this to a form that can be compiled
+                inlineByref v vexpr bexpr
+
             // Handle the generic cases
             | Quotations.ExprShape.ShapeLambda(v,body) -> 
                 Quotations.Expr.Lambda(v, trans body)
             | Quotations.ExprShape.ShapeCombination(comb,args) -> 
                 Quotations.ExprShape.RebuildShapeCombination(comb,List.map trans args)
             | Quotations.ExprShape.ShapeVar _ -> q
-        trans expr
+        and inlineByref v vexpr bexpr =
+            match vexpr with
+            | Quotations.Patterns.Sequential(e',vexpr') ->
+                (* let v = (e'; vexpr') in bexpr => e'; let v = vexpr' in bexpr *)
+                Quotations.Expr.Sequential(e', inlineByref v vexpr' bexpr)
+                |> trans
+            | Quotations.Patterns.IfThenElse(c,b1,b2) ->
+                (* let v = if c then b1 else b2 in bexpr => if c then let v = b1 in bexpr else let v = b2 in bexpr *)
+                Quotations.Expr.IfThenElse(c, inlineByref v b1 bexpr, inlineByref v b2 bexpr)
+                |> trans
+            | Quotations.Patterns.Var _ -> 
+                (* let v = v1 in bexpr => bexpr[v/v1] *)
+                bexpr.Substitute(fun v' -> if v = v' then Some vexpr else None)
+                |> trans
+            | _ -> 
+                failwith (sprintf "Unexpected byref binding: %A = %A" v vexpr)
+        and transValue (v : obj, tyOfValue : Type, expectedTy : Type) = 
+            let rec transArray (o : Array, ty : Type) = 
+                let elemTy = ty.GetElementType()
+                let converter = getConverterForType elemTy
+                let elements = 
+                    [
+                        for el in o do
+                            yield converter el
+                    ]
+                Quotations.Expr.NewArray(elemTy, elements)
+            and transList(o, ty : Type, nil, cons) =
+                let converter = getConverterForType (ty.GetGenericArguments().[0])
+                o
+                |> Seq.cast
+                |> List.ofSeq
+                |> fun l -> List.foldBack(fun o s -> Quotations.Expr.NewUnionCase(cons, [ converter(o); s ])) l (Quotations.Expr.NewUnionCase(nil, []))
+                |> trans
+            and getConverterForType (ty : Type) = 
+                if ty.IsArray then 
+                    fun (v : obj) -> transArray(v :?> Array, ty)
+                elif ty.IsGenericType && ty.GetGenericTypeDefinition() = typedefof<_ list> then 
+                    let nil, cons =
+                        let cases = Reflection.FSharpType.GetUnionCases(ty)
+                        let a = cases.[0]
+                        let b = cases.[1]
+                        if a.Name = "Empty" then a,b
+                        else b,a
+                     
+                    fun v -> transList (v :?> System.Collections.IEnumerable, ty, nil, cons)
+                else 
+                    fun v -> Quotations.Expr.Value(v, ty)
+            let converter = getConverterForType tyOfValue
+            let r = converter v
+            if tyOfValue <> expectedTy then Quotations.Expr.Coerce(r, expectedTy)
+            else r
+        trans q
+
+    // FSharp.Data change: use the real variable names instead of indices, to improve output of Debug.fs
+    let transQuotationToCode isGenerated qexprf (paramNames: string[]) (argExprs: Quotations.Expr[]) = 
+        // add let bindings for arguments to ensure that arguments will be evaluated
+        let vars = argExprs |> Array.mapi (fun i e -> Quotations.Var(paramNames.[i], e.Type))
+        let expr = qexprf ([for v in vars -> Quotations.Expr.Var v])
+
+        let pairs = Array.zip argExprs vars
+        let expr = Array.foldBack (fun (arg, var) e -> Quotations.Expr.Let(var, arg, e)) pairs expr
+
+        transExpr isGenerated expr
 
     let adjustTypeAttributes attributes isNested = 
         let visibilityAttributes = 
@@ -165,36 +314,51 @@ type ProvidedStaticParameter(parameterName:string,parameterType:Type,?parameterD
     override __.GetCustomAttributes(_inherit) = ignore(_inherit); notRequired "GetCustomAttributes" parameterName
     override __.GetCustomAttributes(_attributeType, _inherit) = notRequired "GetCustomAttributes" parameterName
 
-type ProvidedParameter(name:string,parameterType:Type,?isOut:bool,?optionalValue:obj,?isParamArray:bool) = 
+type ProvidedParameter(name:string,parameterType:Type,?isOut:bool,?optionalValue:obj) = 
     inherit System.Reflection.ParameterInfo()
     let customAttributesImpl = CustomAttributesImpl()
     let isOut = defaultArg isOut false
-    do 
-        if defaultArg isParamArray false then
-            customAttributesImpl.AddParamArray()
-
+    member this.IsParamArray with get() = customAttributesImpl.HasParamArray and set(v) = customAttributesImpl.HasParamArray <- v
     override this.Name = name
     override this.ParameterType = parameterType
     override this.Attributes = (base.Attributes ||| (if isOut then ParameterAttributes.Out else enum 0)
                                                 ||| (match optionalValue with None -> enum 0 | Some _ -> ParameterAttributes.Optional ||| ParameterAttributes.HasDefault))
     override this.RawDefaultValue = defaultArg optionalValue null
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
     override __.GetCustomAttributesData() = customAttributesImpl.GetCustomAttributesData()
+#endif
 
 type ProvidedConstructor(parameters : ProvidedParameter list) = 
     inherit ConstructorInfo()
     let parameters  = parameters |> List.map (fun p -> p :> ParameterInfo) 
+    let mutable baseCall  = None
 
     let mutable declaringType = null : System.Type
-    let mutable invokeCode    = None : option<Quotations.Expr[] -> Quotations.Expr>
+    let mutable invokeCode    = None : option<Quotations.Expr list -> Quotations.Expr>
+    let mutable isImplicitCtor  = false
+    let mutable ctorAttributes = MethodAttributes.Public ||| MethodAttributes.RTSpecialName
     let nameText () = sprintf "constructor for %s" (if declaringType=null then "<not yet known type>" else declaringType.FullName)
 
     let customAttributesImpl = CustomAttributesImpl()
+    member this.IsTypeInitializer 
+        with get() = ctorAttributes.HasFlag(MethodAttributes.Static) && ctorAttributes.HasFlag(MethodAttributes.Private)
+        and set(v) = 
+            let typeInitializerAttributes = MethodAttributes.Static ||| MethodAttributes.Private
+            ctorAttributes <- if v then ctorAttributes ||| typeInitializerAttributes else ctorAttributes &&& ~~~typeInitializerAttributes
+
     member this.AddXmlDocComputed xmlDoc                    = customAttributesImpl.AddXmlDocComputed xmlDoc
     member this.AddXmlDocDelayed xmlDoc                     = customAttributesImpl.AddXmlDocDelayed xmlDoc
     member this.AddXmlDoc xmlDoc                            = customAttributesImpl.AddXmlDoc xmlDoc
+    member this.AddObsoleteAttribute (msg,?isError)         = customAttributesImpl.AddObsolete (msg,defaultArg isError false)
     member this.AddDefinitionLocation(line,column,filePath) = customAttributesImpl.AddDefinitionLocation(line, column, filePath)
     member this.HideObjectMethods with set v                = customAttributesImpl.HideObjectMethods <- v
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
     override this.GetCustomAttributesData()                 = customAttributesImpl.GetCustomAttributesData()
+#endif
 
     member this.DeclaringTypeImpl 
         with set x = 
@@ -202,21 +366,34 @@ type ProvidedConstructor(parameters : ProvidedParameter list) =
             declaringType <- x
 
     member this.InvokeCode 
-        with set (q:Quotations.Expr list -> Quotations.Expr) = this.InvokeCodeInternal <- transQuotationToCode q
+        with set (q:Quotations.Expr list -> Quotations.Expr) = 
+            match invokeCode with
+            | None -> invokeCode <- Some q
+            | Some _ -> failwith (sprintf "ProvidedConstructor: code already given for '%s'" (nameText()))        
 
-    member this.InvokeCodeInternal 
-        with get() = 
-            match invokeCode with
-            | Some f -> f
-            | None -> failwith (sprintf "ProvidedConstructor: no invoker for '%s'" (nameText()))
-        and  set f = 
-            match invokeCode with
-            | None -> invokeCode <- Some f
-            | Some _ -> failwith (sprintf "ProvidedConstructor: code already given for '%s'" (nameText()))
+    member this.BaseConstructorCall
+        with set (d:Quotations.Expr list -> (ConstructorInfo * Quotations.Expr list)) = 
+            match baseCall with
+            | None -> baseCall <- Some d
+            | Some _ -> failwith (sprintf "ProvidedConstructor: base call already given for '%s'" (nameText()))        
+
+    member this.GetInvokeCodeInternal isGenerated =
+        match invokeCode with
+        | Some f -> 
+            // FSharp.Data change: use the real variable names instead of indices, to improve output of Debug.fs
+            let paramNames = parameters |> List.map (fun p -> p.Name) |> Array.ofList
+            transQuotationToCode isGenerated f paramNames
+        | None -> failwith (sprintf "ProvidedConstructor: no invoker for '%s'" (nameText()))
+
+    member this.GetBaseConstructorCallInternal isGenerated =
+        match baseCall with
+        | Some f -> Some(fun ctorArgs -> let c,baseCtorArgExprs = f ctorArgs in c, List.map (transExpr isGenerated) baseCtorArgExprs)
+        | None -> None
+    member this.IsImplicitCtor with get() = isImplicitCtor and set v = isImplicitCtor <- v
 
     // Implement overloads
     override this.GetParameters() = parameters |> List.toArray 
-    override this.Attributes = MethodAttributes.Public ||| MethodAttributes.RTSpecialName
+    override this.Attributes = ctorAttributes
     override this.Name = if this.IsStatic then ".cctor" else ".ctor"
     override this.DeclaringType = declaringType |> nonNull "ProvidedConstructor.DeclaringType"                                   
     override this.IsDefined(_attributeType, _inherit) = true 
@@ -236,14 +413,19 @@ type ProvidedMethod(methodName: string, parameters: ProvidedParameter list, retu
     // State
     let mutable declaringType : Type = null
     let mutable methodAttrs   = MethodAttributes.Public
-    let mutable invokeCode    = None : option<Quotations.Expr[] -> Quotations.Expr>
+    let mutable invokeCode    = None : option<Quotations.Expr list -> Quotations.Expr>
 
     let customAttributesImpl = CustomAttributesImpl()
     member this.AddXmlDocComputed xmlDoc                    = customAttributesImpl.AddXmlDocComputed xmlDoc
     member this.AddXmlDocDelayed xmlDoc                     = customAttributesImpl.AddXmlDocDelayed xmlDoc
     member this.AddXmlDoc xmlDoc                            = customAttributesImpl.AddXmlDoc xmlDoc
+    member this.AddObsoleteAttribute (msg,?isError)         = customAttributesImpl.AddObsolete (msg,defaultArg isError false)
     member this.AddDefinitionLocation(line,column,filePath) = customAttributesImpl.AddDefinitionLocation(line, column, filePath)
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
     override this.GetCustomAttributesData()                 = customAttributesImpl.GetCustomAttributesData()
+#endif
 
     member this.SetMethodAttrs m = methodAttrs <- m 
     member this.AddMethodAttrs m = methodAttrs <- methodAttrs ||| m
@@ -253,19 +435,24 @@ type ProvidedMethod(methodName: string, parameters: ProvidedParameter list, retu
         and set x = if x then methodAttrs <- methodAttrs ||| MethodAttributes.Static
                     else methodAttrs <- methodAttrs &&& (~~~ MethodAttributes.Static)
     member this.InvokeCode 
-        with set  (q:Quotations.Expr list -> Quotations.Expr) = this.InvokeCodeInternal <- transQuotationToCode q
-
-    member this.InvokeCodeInternal 
-        with get() = 
+        with set  (q:Quotations.Expr list -> Quotations.Expr) = 
             match invokeCode with
-            | Some f -> f
-            | None -> failwith (sprintf "ProvidedMethod: no invoker for %s on type %s" this.Name (if declaringType=null then "<not yet known type>" else declaringType.FullName))
-        and  set f = 
-            match invokeCode with
-            | None -> invokeCode <- Some f
+            | None -> invokeCode <- Some q
             | Some _ -> failwith (sprintf "ProvidedConstructor: code already given for %s on type %s" this.Name (if declaringType=null then "<not yet known type>" else declaringType.FullName))
 
-    // Implement overloads
+
+    member this.GetInvokeCodeInternal isGenerated =
+        match invokeCode with
+        | Some f -> 
+            // FSharp.Data change: use the real variable names instead of indices, to improve output of Debug.fs
+            let paramNames = 
+                parameters
+                |> List.map (fun p -> p.Name) 
+                |> List.append (if this.IsStatic then [] else ["this"])
+                |> Array.ofList
+            transQuotationToCode isGenerated f paramNames
+        | None -> failwith (sprintf "ProvidedMethod: no invoker for %s on type %s" this.Name (if declaringType=null then "<not yet known type>" else declaringType.FullName))
+   // Implement overloads
     override this.GetParameters() = argParams |> Array.ofList
     override this.Attributes = methodAttrs
     override this.Name = methodName
@@ -279,11 +466,16 @@ type ProvidedMethod(methodName: string, parameters: ProvidedParameter list, retu
     override this.ReturnType = returnType
     override this.ReturnParameter = null // REVIEW: Give it a name and type?
     override this.ToString() = "Method " + this.Name
+    
+    // These don't have to return fully accurate results - they are used 
+    // by the F# Quotations library function SpecificCall as a pre-optimization
+    // when comparing methods
+    override this.MetadataToken = hash declaringType + hash this.Name
+    override this.MethodHandle = RuntimeMethodHandle()
 
     override this.ReturnTypeCustomAttributes                           = notRequired "ReturnTypeCustomAttributes" this.Name
     override this.GetBaseDefinition()                                  = notRequired "GetBaseDefinition" this.Name
     override this.GetMethodImplementationFlags()                       = notRequired "GetMethodImplementationFlags" this.Name
-    override this.MethodHandle                                         = notRequired "MethodHandle" this.Name
     override this.Invoke(_obj, _invokeAttr, _binder, _parameters, _culture) = notRequired "Invoke" this.Name
     override this.ReflectedType                                        = notRequired "ReflectedType" this.Name
     override this.GetCustomAttributes(_inherit)                     = notRequired "GetCustomAttributes" this.Name
@@ -297,23 +489,28 @@ type ProvidedProperty(propertyName:string,propertyType:Type, ?parameters:Provide
     let parameters = defaultArg parameters []
     let mutable declaringType = null
     let mutable isStatic = false
-    let mutable getterCode = None : option<Quotations.Expr[] -> Quotations.Expr>
-    let mutable setterCode = None : option<Quotations.Expr[] -> Quotations.Expr>
+    let mutable getterCode = None : option<Quotations.Expr list -> Quotations.Expr>
+    let mutable setterCode = None : option<Quotations.Expr list -> Quotations.Expr>
 
     let hasGetter() = getterCode.IsSome
     let hasSetter() = setterCode.IsSome
 
     // Delay construction - to pick up the latest isStatic
     let markSpecialName (m:ProvidedMethod) = m.AddMethodAttrs(MethodAttributes.SpecialName); m
-    let getter = lazy (ProvidedMethod("get_" + propertyName,parameters,propertyType,IsStaticMethod=isStatic,DeclaringTypeImpl=declaringType,InvokeCodeInternal=getterCode.Value) |> markSpecialName)  
-    let setter = lazy (ProvidedMethod("set_" + propertyName,parameters @ [ProvidedParameter("value",propertyType)],typeof<System.Void>,IsStaticMethod=isStatic,DeclaringTypeImpl=declaringType,InvokeCodeInternal=setterCode.Value) |> markSpecialName) 
+    let getter = lazy (ProvidedMethod("get_" + propertyName,parameters,propertyType,IsStaticMethod=isStatic,DeclaringTypeImpl=declaringType,InvokeCode=getterCode.Value) |> markSpecialName)  
+    let setter = lazy (ProvidedMethod("set_" + propertyName,parameters @ [ProvidedParameter("value",propertyType)],typeof<System.Void>,IsStaticMethod=isStatic,DeclaringTypeImpl=declaringType,InvokeCode=setterCode.Value) |> markSpecialName) 
  
     let customAttributesImpl = CustomAttributesImpl()
     member this.AddXmlDocComputed xmlDoc                    = customAttributesImpl.AddXmlDocComputed xmlDoc
     member this.AddXmlDocDelayed xmlDoc                     = customAttributesImpl.AddXmlDocDelayed xmlDoc
     member this.AddXmlDoc xmlDoc                            = customAttributesImpl.AddXmlDoc xmlDoc
+    member this.AddObsoleteAttribute (msg,?isError)         = customAttributesImpl.AddObsolete (msg,defaultArg isError false)
     member this.AddDefinitionLocation(line,column,filePath) = customAttributesImpl.AddDefinitionLocation(line, column, filePath)
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
     override this.GetCustomAttributesData()                 = customAttributesImpl.GetCustomAttributesData()
+#endif
 
     member this.DeclaringTypeImpl with set x = declaringType <- x // check: not set twice
     member this.IsStatic 
@@ -321,20 +518,12 @@ type ProvidedProperty(propertyName:string,propertyType:Type, ?parameters:Provide
         and set x = isStatic <- x
 
     member this.GetterCode 
-        with set  (q:Quotations.Expr list -> Quotations.Expr) = this.GetterCodeInternal <- transQuotationToCode q
-
-    member this.GetterCodeInternal 
-        with get() = getterCode.Value
-        and  set f = 
-            if not getter.IsValueCreated then getterCode <- Some f else failwith "ProvidedProperty: getter MethodInfo has already been created"                                         
+        with set  (q:Quotations.Expr list -> Quotations.Expr) = 
+            if not getter.IsValueCreated then getterCode <- Some q else failwith "ProvidedProperty: getter MethodInfo has already been created"
 
     member this.SetterCode 
-        with set (q:Quotations.Expr list -> Quotations.Expr) = this.SetterCodeInternal <- transQuotationToCode q
-
-    member this.SetterCodeInternal 
-        with get() = setterCode.Value
-        and  set f = 
-            if not (setter.IsValueCreated) then setterCode <- Some f else failwith "ProvidedProperty: setter MethodInfo has already been created"
+        with set (q:Quotations.Expr list -> Quotations.Expr) = 
+            if not (setter.IsValueCreated) then setterCode <- Some q else failwith "ProvidedProperty: setter MethodInfo has already been created"
 
     // Implement overloads
     override this.PropertyType = propertyType
@@ -356,6 +545,61 @@ type ProvidedProperty(propertyName:string,propertyType:Type, ?parameters:Provide
     override this.GetCustomAttributes(_attributeType, _inherit)   = notRequired "GetCustomAttributes" this.Name
     override this.IsDefined(_attributeType, _inherit)             = notRequired "IsDefined" this.Name
 
+type ProvidedEvent(eventName:string,eventHandlerType:Type) = 
+    inherit System.Reflection.EventInfo()
+    // State
+
+    let mutable declaringType = null
+    let mutable isStatic = false
+    let mutable adderCode = None : option<Quotations.Expr list -> Quotations.Expr>
+    let mutable removerCode = None : option<Quotations.Expr list -> Quotations.Expr>
+
+    // Delay construction - to pick up the latest isStatic
+    let markSpecialName (m:ProvidedMethod) = m.AddMethodAttrs(MethodAttributes.SpecialName); m
+    let adder = lazy (ProvidedMethod("add_" + eventName, [ProvidedParameter("handler", eventHandlerType)],typeof<System.Void>,IsStaticMethod=isStatic,DeclaringTypeImpl=declaringType,InvokeCode=adderCode.Value) |> markSpecialName)  
+    let remover = lazy (ProvidedMethod("remove_" + eventName, [ProvidedParameter("handler", eventHandlerType)],typeof<System.Void>,IsStaticMethod=isStatic,DeclaringTypeImpl=declaringType,InvokeCode=removerCode.Value) |> markSpecialName) 
+ 
+    let customAttributesImpl = CustomAttributesImpl()
+    member this.AddXmlDocComputed xmlDoc                    = customAttributesImpl.AddXmlDocComputed xmlDoc
+    member this.AddXmlDocDelayed xmlDoc                     = customAttributesImpl.AddXmlDocDelayed xmlDoc
+    member this.AddXmlDoc xmlDoc                            = customAttributesImpl.AddXmlDoc xmlDoc
+    member this.AddDefinitionLocation(line,column,filePath) = customAttributesImpl.AddDefinitionLocation(line, column, filePath)
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
+    override this.GetCustomAttributesData()                 = customAttributesImpl.GetCustomAttributesData()
+#endif
+
+    member this.DeclaringTypeImpl with set x = declaringType <- x // check: not set twice
+    member this.IsStatic 
+        with get()  = isStatic
+        and set x = isStatic <- x
+
+    member this.AdderCode 
+        with get() = adderCode.Value
+        and  set f = 
+            if not adder.IsValueCreated then adderCode <- Some f else failwith "ProvidedEvent: Add MethodInfo has already been created"                                         
+
+    member this.RemoverCode
+        with get() = removerCode.Value
+        and  set f = 
+            if not (remover.IsValueCreated) then removerCode <- Some f else failwith "ProvidedEvent: Remove MethodInfo has already been created"
+
+    // Implement overloads
+    override this.EventHandlerType = eventHandlerType
+    override this.GetAddMethod _nonPublic = adder.Force() :> MethodInfo
+    override this.GetRemoveMethod _nonPublic = remover.Force() :> MethodInfo
+    override this.Attributes = EventAttributes.None
+    override this.Name = eventName
+    override this.DeclaringType = declaringType |> nonNull "ProvidedEvent.DeclaringType"
+    override this.MemberType : MemberTypes = MemberTypes.Event
+
+    override this.GetRaiseMethod _nonPublic                      = notRequired "GetRaiseMethod" this.Name
+    override this.ReflectedType                                     = notRequired "ReflectedType" this.Name
+    override this.GetCustomAttributes(_inherit)                  = notRequired "GetCustomAttributes" this.Name
+    override this.GetCustomAttributes(_attributeType, _inherit)   = notRequired "GetCustomAttributes" this.Name
+    override this.IsDefined(_attributeType, _inherit)             = notRequired "IsDefined" this.Name
+
 type ProvidedLiteralField(fieldName:string,fieldType:Type,literalValue:obj) = 
     inherit System.Reflection.FieldInfo()
     // State
@@ -366,8 +610,13 @@ type ProvidedLiteralField(fieldName:string,fieldType:Type,literalValue:obj) =
     member this.AddXmlDocComputed xmlDoc                    = customAttributesImpl.AddXmlDocComputed xmlDoc
     member this.AddXmlDocDelayed xmlDoc                     = customAttributesImpl.AddXmlDocDelayed xmlDoc
     member this.AddXmlDoc xmlDoc                            = customAttributesImpl.AddXmlDoc xmlDoc
+    member this.AddObsoleteAttribute (msg,?isError)         = customAttributesImpl.AddObsolete (msg,defaultArg isError false)
     member this.AddDefinitionLocation(line,column,filePath) = customAttributesImpl.AddDefinitionLocation(line, column, filePath)
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
     override this.GetCustomAttributesData()                 = customAttributesImpl.GetCustomAttributesData()
+#endif
 
     member this.DeclaringTypeImpl with set x = declaringType <- x // check: not set twice
 
@@ -389,8 +638,53 @@ type ProvidedLiteralField(fieldName:string,fieldType:Type,literalValue:obj) =
     override this.GetValue(_obj) : obj = notRequired "GetValue" this.Name
     override this.FieldHandle = notRequired "FieldHandle" this.Name
 
+type ProvidedField(fieldName:string,fieldType:Type) = 
+    inherit System.Reflection.FieldInfo()
+    // State
+
+    let mutable declaringType = null
+
+    let customAttributesImpl = CustomAttributesImpl()
+    let mutable fieldAttrs = FieldAttributes.Private
+    member this.AddXmlDocComputed xmlDoc                    = customAttributesImpl.AddXmlDocComputed xmlDoc
+    member this.AddXmlDocDelayed xmlDoc                     = customAttributesImpl.AddXmlDocDelayed xmlDoc
+    member this.AddXmlDoc xmlDoc                            = customAttributesImpl.AddXmlDoc xmlDoc
+    member this.AddObsoleteAttribute (msg,?isError)         = customAttributesImpl.AddObsolete (msg,defaultArg isError false)
+    member this.AddDefinitionLocation(line,column,filePath) = customAttributesImpl.AddDefinitionLocation(line, column, filePath)
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
+    override this.GetCustomAttributesData()                 = customAttributesImpl.GetCustomAttributesData()
+#endif
+
+    member this.DeclaringTypeImpl with set x = declaringType <- x // check: not set twice
+
+    member this.SetFieldAttributes attrs = fieldAttrs <- attrs
+    // Implement overloads
+    override this.FieldType = fieldType
+    override this.GetRawConstantValue()  = null
+    override this.Attributes = fieldAttrs
+    override this.Name = fieldName
+    override this.DeclaringType = declaringType |> nonNull "ProvidedField.DeclaringType"
+    override this.MemberType : MemberTypes = MemberTypes.Field
+
+    override this.ReflectedType                                     = notRequired "ReflectedType" this.Name
+    override this.GetCustomAttributes(_inherit)                  = notRequired "GetCustomAttributes" this.Name
+    override this.GetCustomAttributes(_attributeType, _inherit)   = notRequired "GetCustomAttributes" this.Name
+    override this.IsDefined(_attributeType, _inherit)             = notRequired "IsDefined" this.Name
+
+    override this.SetValue(_obj, _value, _invokeAttr, _binder, _culture) = notRequired "SetValue" this.Name
+    override this.GetValue(_obj) : obj = notRequired "GetValue" this.Name
+    override this.FieldHandle = notRequired "FieldHandle" this.Name
+
 /// Represents the type constructor in a provided symbol type.
-type SymbolKind = SDArray | Array of int | Pointer | ByRef | Generic of System.Type
+type SymbolKind = 
+    | SDArray 
+    | Array of int 
+    | Pointer 
+    | ByRef 
+    | Generic of System.Type 
+    | FSharpTypeAbbreviation of (System.Reflection.Assembly * string * string[])
 
 
 /// Represents an array or other symbolic type involving a provided type as the argument.
@@ -399,13 +693,34 @@ type SymbolKind = SDArray | Array of int | Pointer | ByRef | Generic of System.T
 type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
     inherit Type()
 
+    static member convType (parameters: Type list) (ty:Type) = 
+        if ty.IsGenericType then 
+            let args = Array.map (ProvidedSymbolType.convType parameters) (ty.GetGenericArguments())
+            ProvidedSymbolType(Generic (ty.GetGenericTypeDefinition()), Array.toList args)  :> Type
+        elif ty.HasElementType then 
+            let ety = ProvidedSymbolType.convType parameters (ty.GetElementType()) 
+            if ty.IsArray then 
+                let rank = ty.GetArrayRank()
+                if rank = 1 then ProvidedSymbolType(SDArray,[ety]) :> Type
+                else ProvidedSymbolType(Array rank,[ety]) :> Type
+            elif ty.IsPointer then ProvidedSymbolType(Pointer,[ety]) :> Type
+            elif ty.IsByRef then ProvidedSymbolType(ByRef,[ety]) :> Type
+            else ty
+        elif ty.IsGenericParameter then 
+            if ty.GenericParameterPosition <= parameters.Length - 1 then 
+                parameters.[ty.GenericParameterPosition]
+            else
+                ty
+        else ty
+
     override this.FullName =   
         match kind,args with 
         | SymbolKind.SDArray,[arg] -> arg.FullName + "[]" 
         | SymbolKind.Array _,[arg] -> arg.FullName + "[*]" 
         | SymbolKind.Pointer,[arg] -> arg.FullName + "*" 
         | SymbolKind.ByRef,[arg] -> arg.FullName + "&"
-        | SymbolKind.Generic gty, args -> gty.FullName + args.ToString()
+        | SymbolKind.Generic gty, args -> gty.FullName + "[" + (args |> List.map (fun arg -> arg.ToString()) |> String.concat ",") + "]"
+        | SymbolKind.FSharpTypeAbbreviation (_,nsp,path),args -> String.concat "." (Array.append [| nsp |] path) + args.ToString()
         | _ -> failwith "unreachable"
    
     /// Although not strictly required by the type provider specification, this is required when doing basic operations like FullName on
@@ -417,7 +732,20 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
         | SymbolKind.Pointer,[arg] -> arg
         | SymbolKind.ByRef,[arg] -> arg
         | SymbolKind.Generic gty,_ -> gty
+        | SymbolKind.FSharpTypeAbbreviation _,_ -> null
         | _ -> failwith "unreachable"
+
+    override this.IsAssignableFrom(otherTy) = 
+        match kind with
+        | Generic gtd ->
+            if otherTy.IsGenericType then
+                let otherGtd = otherTy.GetGenericTypeDefinition()
+                let otherArgs = otherTy.GetGenericArguments()
+                let yes = gtd.Equals(otherGtd) && Seq.forall2 (=) args otherArgs
+                yes
+                else
+                    base.IsAssignableFrom(otherTy)
+        | _ -> base.IsAssignableFrom(otherTy)
 
     override this.Name =
         match kind,args with 
@@ -426,6 +754,7 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
         | SymbolKind.Pointer,[arg] -> arg.Name + "*" 
         | SymbolKind.ByRef,[arg] -> arg.Name + "&"
         | SymbolKind.Generic gty, args -> gty.FullName + args.ToString()
+        | SymbolKind.FSharpTypeAbbreviation (_,_,path),_ -> path.[path.Length-1]
         | _ -> failwith "unreachable"
 
     override this.BaseType =
@@ -434,7 +763,8 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
         | SymbolKind.Array _ -> typeof<System.Array>
         | SymbolKind.Pointer -> typeof<System.ValueType>
         | SymbolKind.ByRef -> typeof<System.ValueType>
-        | SymbolKind.Generic gty  -> gty.BaseType
+        | SymbolKind.Generic gty  -> ProvidedSymbolType.convType args gty.BaseType
+        | SymbolKind.FSharpTypeAbbreviation _ -> typeof<obj>
 
     override this.GetArrayRank() = (match kind with SymbolKind.Array n -> n | SymbolKind.SDArray -> 1 | _ -> invalidOp "non-array type")
     override this.IsArrayImpl() = (match kind with SymbolKind.Array _ | SymbolKind.SDArray -> true | _ -> false)
@@ -450,10 +780,40 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
     override this.ToString() = this.FullName
 
     override this.Module : Module                                                                  = notRequired "Module" this.Name
-    override this.Assembly                                                                         = notRequired "Assembly" this.Name
-    override this.Namespace                                                                        = notRequired "Namespace" this.Name
+    override this.Assembly = 
+        match kind with 
+        | SymbolKind.FSharpTypeAbbreviation (assembly,_nsp,_path) -> assembly
+        | SymbolKind.Generic gty -> gty.Assembly
+        | _ -> notRequired "Assembly" this.Name
+    override this.Namespace = 
+        match kind with 
+        | SymbolKind.FSharpTypeAbbreviation (_assembly,nsp,_path) -> nsp
+        | _ -> notRequired "Namespace" this.Name
+
+    override this.GetHashCode()                                                                    = 
+        match kind,args with 
+        | SymbolKind.SDArray,[arg] -> 10 + hash arg
+        | SymbolKind.Array _,[arg] -> 163 + hash arg
+        | SymbolKind.Pointer,[arg] -> 283 + hash arg
+        | SymbolKind.ByRef,[arg] -> 43904 + hash arg
+        | SymbolKind.Generic gty,_ -> 9797 + hash gty + List.sumBy hash args
+        | SymbolKind.FSharpTypeAbbreviation _,_ -> 3092
+        | _ -> failwith "unreachable"
+    member this.Kind = kind
+    member this.Args = args
+    
+    override this.Equals(that:obj) = 
+        match that with 
+        | :? ProvidedSymbolType as that -> (kind,args) = (that.Kind, that.Args)
+        | _ -> false
+
     override this.GetConstructors _bindingAttr                                                      = notRequired "GetConstructors" this.Name
-    override this.GetMethodImpl(_name, _bindingAttr, _binderBinder, _callConvention, _types, _modifiers) = notRequired "GetMethodImpl" this.Name
+    override this.GetMethodImpl(_name, _bindingAttr, _binderBinder, _callConvention, _types, _modifiers) = 
+        match kind with
+        | Generic gtd -> 
+            let ty = gtd.GetGenericTypeDefinition().MakeGenericType(Array.ofList args)
+            ty.GetMethod(_name, _bindingAttr)
+        | _ -> notRequired "GetMethodImpl" this.Name
     override this.GetMembers _bindingAttr                                                           = notRequired "GetMembers" this.Name
     override this.GetMethods _bindingAttr                                                           = notRequired "GetMethods" this.Name
     override this.GetField(_name, _bindingAttr)                                                      = notRequired "GetField" this.Name
@@ -467,22 +827,89 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
     override this.GetNestedTypes _bindingAttr                                                       = notRequired "GetNestedTypes" this.Name
     override this.GetNestedType(_name, _bindingAttr)                                                 = notRequired "GetNestedType" this.Name
     override this.GetAttributeFlagsImpl()                                                          = notRequired "GetAttributeFlagsImpl" this.Name
-    override this.UnderlyingSystemType                                                             = notRequired "UnderlyingSystemType" this.Name
-    override this.GetCustomAttributesData()                                                        = notRequired "GetCustomAttributesData" this.Name
+    override this.UnderlyingSystemType                                                             = 
+        match kind with 
+        | SymbolKind.SDArray
+        | SymbolKind.Array _
+        | SymbolKind.Pointer
+        | SymbolKind.FSharpTypeAbbreviation _
+        | SymbolKind.ByRef -> notRequired "UnderlyingSystemType" this.Name
+        | SymbolKind.Generic gty -> gty.UnderlyingSystemType      
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
+    override this.GetCustomAttributesData()                                                        =  ([| |] :> IList<_>)
+#endif
     override this.MemberType                                                                       = notRequired "MemberType" this.Name
-    override this.GetHashCode()                                                                    = notRequired "GetHashCode" this.Name
-    override this.Equals(_that:obj) : bool                                                          = notRequired "Equals" this.Name
-    override this.GetMember(_name,_mt,_bindingAttr)                                                   = notRequired "GetMember" this.Name
+    override this.GetMember(_name,_mt,_bindingAttr)                                                = notRequired "GetMember" this.Name
     override this.GUID                                                                             = notRequired "GUID" this.Name
     override this.InvokeMember(_name, _invokeAttr, _binder, _target, _args, _modifiers, _culture, _namedParameters) = notRequired "InvokeMember" this.Name
     override this.AssemblyQualifiedName                                                            = notRequired "AssemblyQualifiedName" this.Name
-    override this.GetConstructorImpl(_bindingAttr, _binder, _callConvention, _types, _modifiers)        = notRequired "GetConstructorImpl" this.Name
-    override this.GetCustomAttributes(_inherit)                                                 = notRequired "GetCustomAttributes" this.Name
-    override this.GetCustomAttributes(_attributeType, _inherit)                                  = notRequired "GetCustomAttributes" this.Name
-    override this.IsDefined(_attributeType, _inherit)                                            = notRequired "IsDefined" this.Name
+    override this.GetConstructorImpl(_bindingAttr, _binder, _callConvention, _types, _modifiers)   = notRequired "GetConstructorImpl" this.Name
+    override this.GetCustomAttributes(_inherit)                                                    = [| |]
+    override this.GetCustomAttributes(_attributeType, _inherit)                                    = [| |]
+    override this.IsDefined(_attributeType, _inherit)                                              = false
+
+type ProvidedSymbolMethod(genericMethodDefinition: MethodInfo, parameters: Type list) =
+    inherit System.Reflection.MethodInfo()
+
+    let convParam (p:ParameterInfo) = 
+        { new System.Reflection.ParameterInfo() with
+              override this.Name = p.Name
+              override this.ParameterType = ProvidedSymbolType.convType parameters p.ParameterType
+              override this.Attributes = p.Attributes
+              override this.RawDefaultValue = p.RawDefaultValue
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
+              override __.GetCustomAttributesData() = p.GetCustomAttributesData()
+#endif
+        } 
+    override this.IsGenericMethod = 
+        (if this.DeclaringType.IsGenericType then this.DeclaringType.GetGenericArguments().Length else 0) < parameters.Length
+    override this.GetGenericArguments() = 
+        Seq.skip (if this.DeclaringType.IsGenericType then this.DeclaringType.GetGenericArguments().Length else 0) parameters |> Seq.toArray 
+    override this.GetGenericMethodDefinition() = genericMethodDefinition
+    override this.DeclaringType = ProvidedSymbolType.convType parameters genericMethodDefinition.DeclaringType
+    override this.ToString() = "Method " + this.Name
+    override this.Name = genericMethodDefinition.Name
+    override this.MetadataToken = genericMethodDefinition.MetadataToken
+    override this.Attributes = genericMethodDefinition.Attributes
+    override this.CallingConvention = genericMethodDefinition.CallingConvention
+    override this.MemberType = genericMethodDefinition.MemberType
+
+    override this.IsDefined(_attributeType, _inherit) : bool = notRequired "IsDefined" this.Name
+    override this.ReturnType = ProvidedSymbolType.convType parameters genericMethodDefinition.ReturnType
+    override this.GetParameters() = genericMethodDefinition.GetParameters() |> Array.map convParam
+    override this.ReturnParameter = genericMethodDefinition.ReturnParameter |> convParam
+    override this.ReturnTypeCustomAttributes                           = notRequired "ReturnTypeCustomAttributes" this.Name
+    override this.GetBaseDefinition()                                  = notRequired "GetBaseDefinition" this.Name
+    override this.GetMethodImplementationFlags()                       = notRequired "GetMethodImplementationFlags" this.Name
+    override this.MethodHandle                                         = notRequired "MethodHandle" this.Name
+    override this.Invoke(_obj, _invokeAttr, _binder, _parameters, _culture) = notRequired "Invoke" this.Name
+    override this.ReflectedType                                        = notRequired "ReflectedType" this.Name
+    override this.GetCustomAttributes(_inherit)                     = notRequired "GetCustomAttributes" this.Name
+    override this.GetCustomAttributes(_attributeType, _inherit)      =  notRequired "GetCustomAttributes" this.Name 
+
+
+
+type ProvidedTypeBuilder() =
+    static member MakeGenericType(genericTypeDefinition, genericArguments) = ProvidedSymbolType(Generic genericTypeDefinition, genericArguments) :> Type
+    static member MakeGenericMethod(genericMethodDefinition, genericArguments) = ProvidedSymbolMethod(genericMethodDefinition, genericArguments) :> MethodInfo
 
 [<Class>]
 type ProvidedMeasureBuilder() =
+
+    // TODO: this shouldn't be hardcoded, but without creating a dependency on Microsoft.FSharp.Metadata in F# PowerPack
+    // there seems to be no way to check if a type abbreviation exists
+    let unitNamesTypeAbbreviations = 
+        [ "meter"; "hertz"; "newton"; "pascal"; "joule"; "watt"; "coulomb"; 
+          "volt"; "farad"; "ohm"; "siemens"; "weber"; "tesla"; "henry"
+          "lumen"; "lux"; "becquerel"; "gray"; "sievert"; "katal" ]
+        |> Set.ofList
+
+    let unitSymbolsTypeAbbreviations = 
+        [ "m"; "kg"; "s"; "A"; "K"; "mol"; "cd"; "Hz"; "N"; "Pa"; "J"; "W"; "C"
+          "V"; "F"; "S"; "Wb"; "T"; "lm"; "lx"; "Bq"; "Gy"; "Sv"; "kat"; "H" ]
+        |> Set.ofList
 
     static let theBuilder = ProvidedMeasureBuilder()
     static member Default = theBuilder
@@ -491,11 +918,32 @@ type ProvidedMeasureBuilder() =
     member b.Inverse m = typedefof<Core.CompilerServices.MeasureInverse<_>>.MakeGenericType [| m |] 
     member b.Ratio (m1, m2) = b.Product(m1, b.Inverse m2)
     member b.Square m = b.Product(m, m)
-    member b.SI m = 
-        match typedefof<list<int>>.Assembly.GetType("Microsoft.FSharp.Data.UnitSystems.SI.UnitNames."+m) with 
-        | null -> failwith (sprintf "Unit '%s' not found in FSharp.Core SI  module" m) 
-        | v -> v
+
+    // FSharp.Data change: if the unit is not a valid type, instead 
+    // of assuming it's a type abbreviation, which may not be the case and cause a
+    // problem later on, check the list of valid abbreviations
+    member b.SI (m:string) = 
+        let mLowerCase = m.ToLowerInvariant()
+        let abbreviation =            
+            if unitNamesTypeAbbreviations.Contains mLowerCase then
+                Some ("Microsoft.FSharp.Data.UnitSystems.SI.UnitNames", mLowerCase)
+            elif unitSymbolsTypeAbbreviations.Contains m then
+                Some ("Microsoft.FSharp.Data.UnitSystems.SI.UnitSymbols", m)
+            else
+                None
+        match abbreviation with
+        | Some (ns, unitName) ->
+            ProvidedSymbolType
+               (SymbolKind.FSharpTypeAbbreviation
+                   (typeof<Core.CompilerServices.MeasureOne>.Assembly,
+                    ns,
+                    [| unitName |]), 
+                []) :> Type
+        | None ->
+            typedefof<list<int>>.Assembly.GetType("Microsoft.FSharp.Data.UnitSystems.SI.UnitNames." + mLowerCase)
+
     member b.AnnotateType (basicType, annotation) = ProvidedSymbolType(Generic basicType, annotation) :> Type
+
 
 
 [<RequireQualifiedAccess>]
@@ -505,7 +953,7 @@ type TypeContainer =
   | TypeToBeDecided
 
 module GlobalProvidedAssemblyElementsTable = 
-    let theTable = Dictionary<Assembly, byte[]>()
+    let theTable = Dictionary<Assembly, Lazy<byte[]>>()
 
 type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType  : Type option) as this =
     inherit Type()
@@ -517,13 +965,14 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
         enum (int32 TypeProviderTypeAttributes.IsErased)
 
 
-    let mutable baseType   = baseType
+    let mutable baseType   =  lazy baseType
     let mutable membersKnown   = ResizeArray<MemberInfo>()
     let mutable membersQueue   = ResizeArray<(unit -> list<MemberInfo>)>()       
     let mutable staticParams = [ ] 
     let mutable staticParamsApply = None
     let mutable container = container
     let mutable interfaceImpls = ResizeArray<Type>()
+    let mutable interfaceImplsDelayed = ResizeArray<unit -> list<Type>>()
     let mutable methodOverrides = ResizeArray<ProvidedMethod * MethodInfo>()
 
     // members API
@@ -538,9 +987,23 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
                     | :? ProvidedProperty    as p -> 
                         if p.CanRead then membersKnown.Add (p.GetGetMethod true)
                         if p.CanWrite then membersKnown.Add (p.GetSetMethod true)
+                    | :? ProvidedEvent       as e -> 
+                        membersKnown.Add (e.GetAddMethod true)
+                        membersKnown.Add (e.GetRemoveMethod true)
                     | _ -> ()
         
         membersKnown.ToArray()
+
+            // members API
+    let getInterfaces() = 
+        if interfaceImplsDelayed.Count > 0 then 
+            let elems = interfaceImplsDelayed |> Seq.toArray // take a copy in case more elements get added
+            interfaceImplsDelayed.Clear()
+            for  f in elems do
+                for i in f() do 
+                    interfaceImpls.Add i       
+        
+        interfaceImpls.ToArray()
 
     let mutable theAssembly = 
       lazy
@@ -582,23 +1045,33 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
         | :? ProvidedConstructor as c -> c.DeclaringTypeImpl <- this // patch up "declaring type" on provided MethodInfo
         | :? ProvidedMethod      as m -> m.DeclaringTypeImpl <- this // patch up "declaring type" on provided MethodInfo
         | :? ProvidedProperty    as p -> p.DeclaringTypeImpl <- this // patch up "declaring type" on provided MethodInfo
+        | :? ProvidedEvent       as e -> e.DeclaringTypeImpl <- this // patch up "declaring type" on provided MethodInfo
         | :? ProvidedTypeDefinition  as t -> t.DeclaringTypeImpl <- this 
         | :? ProvidedLiteralField as l -> l.DeclaringTypeImpl <- this
+        | :? ProvidedField as l -> l.DeclaringTypeImpl <- this
         | _ -> ()
 
     let customAttributesImpl = CustomAttributesImpl()
     member this.AddXmlDocComputed xmlDoc                    = customAttributesImpl.AddXmlDocComputed xmlDoc
     member this.AddXmlDocDelayed xmlDoc                     = customAttributesImpl.AddXmlDocDelayed xmlDoc
     member this.AddXmlDoc xmlDoc                            = customAttributesImpl.AddXmlDoc xmlDoc
+    member this.AddObsoleteAttribute (msg,?isError)         = customAttributesImpl.AddObsolete (msg,defaultArg isError false)
     member this.AddDefinitionLocation(line,column,filePath) = customAttributesImpl.AddDefinitionLocation(line, column, filePath)
     member this.HideObjectMethods with set v                = customAttributesImpl.HideObjectMethods <- v
+    member __.GetCustomAttributesDataImpl() = customAttributesImpl.GetCustomAttributesData()
+#if FX_NO_CUSTOMATTRIBUTEDATA
+#else
     override this.GetCustomAttributesData()                 = customAttributesImpl.GetCustomAttributesData()
+#endif
 
+    member this.ResetEnclosingType (ty) = 
+        container <- TypeContainer.Type ty
     new (assembly:Assembly,namespaceName,className,baseType) = new ProvidedTypeDefinition(TypeContainer.Namespace (assembly,namespaceName), className, baseType)
     new (className,baseType) = new ProvidedTypeDefinition(TypeContainer.TypeToBeDecided, className, baseType)
     // state ops
 
-    member this.SetBaseType t = baseType <- Some t
+    member this.SetBaseType t = baseType <- lazy Some t
+    member this.SetBaseTypeDelayed t = baseType <- t
     member this.SetAttributes x = attributes <- x
     // Add MemberInfos
     member this.AddMembersDelayed(makeMS : unit -> list<#MemberInfo>) =
@@ -674,18 +1147,20 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
     // Implement overloads
     override this.Assembly = theAssembly.Force()
     member this.SetAssembly assembly = theAssembly <- lazy assembly
+    member this.SetAssemblyLazy assembly = theAssembly <- assembly
     override this.FullName = fullName.Force()
     override this.Namespace = rootNamespace.Force()
-    override this.BaseType = match baseType with Some ty -> ty | None -> null
+    override this.BaseType = match baseType.Value with Some ty -> ty | None -> null
+    
     // Constructors
     override this.GetConstructors bindingAttr = 
         [| for m in this.GetMembers bindingAttr do                
                 if m.MemberType = MemberTypes.Constructor then
                     yield (m :?> ConstructorInfo) |]
     // Methods
-    override this.GetMethodImpl(name, _bindingAttr, _binderBinder, _callConvention, _types, _modifiers) : MethodInfo = 
+    override this.GetMethodImpl(name, bindingAttr, _binderBinder, _callConvention, _types, _modifiers) : MethodInfo = 
         let membersWithName = 
-            [ for m in getMembers() do                
+            [ for m in this.GetMembers(bindingAttr) do                
                 if m.MemberType.HasFlag(MemberTypes.Method) && m.Name = name then
                     yield  m ]
         match membersWithName with 
@@ -711,12 +1186,13 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
     override this.GetInterface(_name, _ignoreCase) = notRequired "GetInterface" this.Name
 
     override this.GetInterfaces() = 
-        [| yield! interfaceImpls  |]
+        [| yield! getInterfaces()  |]
 
     member this.GetInterfaceImplementations() = 
-        [| yield! interfaceImpls |]
+        [| yield! getInterfaces() |]
 
     member this.AddInterfaceImplementation ityp = interfaceImpls.Add ityp
+    member this.AddInterfaceImplementationsDelayed itypf = interfaceImplsDelayed.Add itypf
     member this.GetMethodOverrides() = 
         [| yield! methodOverrides |]
     member this.DefineMethodOverride (bodyMethInfo,declMethInfo) = methodOverrides.Add (bodyMethInfo, declMethInfo)
@@ -750,7 +1226,66 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
     override this.MakePointerType() = ProvidedSymbolType(SymbolKind.Pointer, [this]) :> Type
     override this.MakeByRefType() = ProvidedSymbolType(SymbolKind.ByRef, [this]) :> Type
 
-    override this.GetMembers _bindingAttr = getMembers() 
+    // FSharp.Data addition: this method is used by Debug.fs and QuotationBuilder.fs
+    // Emulate the F# type provider type erasure mechanism to get the 
+    // actual (erased) type. We erase ProvidedTypes to their base type
+    // and we erase array of provided type to array of base type. In the
+    // case of generics all the generic type arguments are also recursively
+    // replaced with the erased-to types
+    static member EraseType(t:Type) =
+        match t with
+        | :? ProvidedTypeDefinition -> ProvidedTypeDefinition.EraseType t.BaseType 
+        | :? ProvidedSymbolType as sym ->
+            match sym.Kind, sym.Args with
+            | SymbolKind.SDArray, [typ] -> 
+                let (t:Type) = ProvidedTypeDefinition.EraseType typ
+                t.MakeArrayType()
+            | SymbolKind.Generic genericTypeDefinition, typeArgs ->
+                let genericArguments =
+                  typeArgs
+                  |> List.toArray
+                  |> Array.map ProvidedTypeDefinition.EraseType
+                genericTypeDefinition.MakeGenericType(genericArguments)
+            | _ -> failwith "getTypeErasedTo: Unsupported ProvidedSymbolType" 
+        | t when t.IsGenericType && not t.IsGenericTypeDefinition ->
+            let genericTypeDefinition = t.GetGenericTypeDefinition()
+            let genericArguments = 
+              t.GetGenericArguments()
+              |> Array.map ProvidedTypeDefinition.EraseType
+            genericTypeDefinition.MakeGenericType(genericArguments)
+        | t -> t
+
+    // The binding attributes are always set to DeclaredOnly ||| Static ||| Instance ||| Public when GetMembers is called directly by the F# compiler
+    // However, it's possible for the framework to generate other sets of flags in some corner cases (e.g. via use of `enum` with a provided type as the target)
+    override this.GetMembers bindingAttr = 
+        let mems = 
+            getMembers() 
+            |> Array.filter (fun mem -> 
+                                let isStatic, isPublic = 
+                                    match mem with
+                                    | :? FieldInfo as f -> f.IsStatic, f.IsPublic
+                                    | :? MethodInfo as m -> m.IsStatic, m.IsPublic
+                                    | :? ConstructorInfo as c -> c.IsStatic, c.IsPublic
+                                    | :? PropertyInfo as p -> 
+                                        let m = if p.CanRead then p.GetGetMethod() else p.GetSetMethod()
+                                        m.IsStatic, m.IsPublic
+                                    | :? EventInfo as e -> 
+                                        let m = e.GetAddMethod()
+                                        m.IsStatic, m.IsPublic
+                                    | :? Type as ty -> 
+                                        true, ty.IsNestedPublic
+                                    | _ -> failwith (sprintf "Member %O is of unexpected type" mem)
+                                bindingAttr.HasFlag(if isStatic then BindingFlags.Static else BindingFlags.Instance) &&
+                                (
+                                    (bindingAttr.HasFlag(BindingFlags.Public) && isPublic) || (bindingAttr.HasFlag(BindingFlags.NonPublic) && not isPublic)
+                                ))
+
+        if bindingAttr.HasFlag(BindingFlags.DeclaredOnly) || this.BaseType = null then mems
+        else 
+            // FSharp.Data change: just using this.BaseType is not enough in the case of CsvProvider,
+            // because the base type is CsvRow<RowType>, so we have to erase recursively to CsvRow<TupleType>
+            let baseMems = (ProvidedTypeDefinition.EraseType this.BaseType).GetMembers bindingAttr
+            Array.append mems baseMems
 
     override this.GetNestedTypes bindingAttr = 
         this.GetMembers bindingAttr 
@@ -794,7 +1329,7 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
         | _                 -> false
 
     override this.GetGenericArguments() = [||] 
-    override this.ToString() = this.FullName
+    override this.ToString() = this.Name
     
 
     override this.Module : Module = notRequired "Module" this.Name
@@ -819,330 +1354,780 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
            if v then attributes <- attributes ||| enum (int32 TypeProviderTypeAttributes.SuppressRelocate)
            else attributes <- attributes &&& ~~~(enum (int32 TypeProviderTypeAttributes.SuppressRelocate))
 
-    static member RegisterGenerated (fileName:string) = 
-        let assemblyBytes = System.IO.File.ReadAllBytes fileName
-        let assembly = Assembly.Load(assemblyBytes,null,System.Security.SecurityContextSource.CurrentAppDomain)
-        GlobalProvidedAssemblyElementsTable.theTable.Add(assembly, assemblyBytes)
-        assembly
-
+type AssemblyGenerator(assemblyFileName) = 
+    let assemblyShortName = Path.GetFileNameWithoutExtension assemblyFileName
+    let assemblyName = AssemblyName assemblyShortName
+#if FX_NO_LOCAL_FILESYSTEM
+    let assembly = 
+        System.AppDomain.CurrentDomain.DefineDynamicAssembly(name=assemblyName,access=AssemblyBuilderAccess.Run)
+    let assemblyMainModule = 
+        assembly.DefineDynamicModule("MainModule")
+#else
+    let assembly = 
+        System.AppDomain.CurrentDomain.DefineDynamicAssembly(name=assemblyName,access=(AssemblyBuilderAccess.Save ||| AssemblyBuilderAccess.Run),dir=Path.GetDirectoryName assemblyFileName)
+    let assemblyMainModule = 
+        assembly.DefineDynamicModule("MainModule", Path.GetFileName assemblyFileName)
+#endif
+    let typeMap = Dictionary<ProvidedTypeDefinition,TypeBuilder>(HashIdentity.Reference)
+    let typeMapExtra = Dictionary<string,TypeBuilder>(HashIdentity.Structural)
+    let uniqueLambdaTypeName() = 
+        // lambda name should be unique across all types that all type provider might contribute in result assembly
+        sprintf "Lambda%O" (Guid.NewGuid()) 
+    member __.Assembly = assembly :> Assembly
     /// Emit the given provided type definitions into an assembly and adjust 'Assembly' property of all type definitions to return that
     /// assembly.
-    member this.ConvertToGenerated (assemblyFileName: string, ?reportAssemblyElements) = 
-        if this.IsErased then invalidOp ("The provided type "+this.Name+"is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
-        let typeDefinitions = [this]
-        let theElementsLazy = 
-           lazy 
-              let assemblyShortName = Path.GetFileNameWithoutExtension assemblyFileName
-              let assemblyName = AssemblyName assemblyShortName
-              let assembly = 
-                  System.AppDomain.CurrentDomain.DefineDynamicAssembly(name=assemblyName,access=AssemblyBuilderAccess.Save,dir=Path.GetDirectoryName assemblyFileName)
-              let assemblyMainModule = 
-                  assembly.DefineDynamicModule("MainModule", Path.GetFileName assemblyFileName)
-              let typeMap = Dictionary(HashIdentity.Reference)
+    member __.Generate(providedTypeDefinitions:(ProvidedTypeDefinition * string list option) list) = 
+        let ALL = BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Static ||| BindingFlags.Instance
+        // phase 1 - set assembly fields and emit type definitions
+        begin 
+            let rec typeMembers (tb:TypeBuilder)  (td : ProvidedTypeDefinition) = 
+                for ntd in td.GetNestedTypes(ALL) do
+                    nestedType tb ntd
 
-              // phase 1 - set assembly fields and emit type definitions
-              begin 
-                  let rec typeMembers (tb:TypeBuilder)  (td : ProvidedTypeDefinition) = 
-                      for ntd in td.GetNestedTypes(BindingFlags.Public ||| BindingFlags.NonPublic) do
-                          nestedType tb ntd
-
-                  and nestedType (tb:TypeBuilder)  (ntd : Type) = 
-                      match ntd with 
-                      | :? ProvidedTypeDefinition as pntd -> 
-                          if pntd.IsErased then invalidOp ("The nested provided type "+pntd.Name+"is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
-                          // Adjust the attributes - we're codegen'ing this type as nested
-                          let attributes = adjustTypeAttributes ntd.Attributes true
-                          let ntb = tb.DefineNestedType(pntd.Name,attr=attributes)
-                          pntd.SetAssembly null
-                          typeMap.[pntd] <- ntb
-                          typeMembers ntb pntd
-                      | _ -> ()
+            and nestedType (tb:TypeBuilder)  (ntd : Type) = 
+                match ntd with 
+                | :? ProvidedTypeDefinition as pntd -> 
+                    if pntd.IsErased then invalidOp ("The nested provided type "+pntd.Name+"is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
+                    // Adjust the attributes - we're codegen'ing this type as nested
+                    let attributes = adjustTypeAttributes ntd.Attributes true
+                    let ntb = tb.DefineNestedType(pntd.Name,attr=attributes)
+                    pntd.SetAssembly null
+                    typeMap.[pntd] <- ntb
+                    typeMembers ntb pntd
+                | _ -> ()
                      
-                  for td in typeDefinitions do 
-                      // Filter out the additional TypeProviderTypeAttributes flags
-                      let attributes = td.Attributes &&& ~~~(enum (int32 TypeProviderTypeAttributes.SuppressRelocate))
-                                                     &&& ~~~(enum (int32 TypeProviderTypeAttributes.IsErased))
-                      // Adjust the attributes - we're codegen'ing as non-nested
-                      let attributes = adjustTypeAttributes attributes false 
-                      let tb = assemblyMainModule.DefineType(name=td.FullName,attr=attributes) 
-                      td.SetAssembly null
-                      typeMap.[td] <- tb
-                      typeMembers tb td 
-              end
-              let rec convType (ty:Type) = 
-                  match ty with 
-                  | :? ProvidedTypeDefinition as ptd ->   
-                      if typeMap.ContainsKey ptd then typeMap.[ptd] :> Type else ty
-                  | _ -> 
-                      if ty.IsGenericType then ty.GetGenericTypeDefinition().MakeGenericType (Array.map convType (ty.GetGenericArguments()))
-                      elif ty.HasElementType then 
-                         let ety = convType (ty.GetElementType()) 
-                         if ty.IsArray then 
-                             let rank = ty.GetArrayRank()
-                             if rank = 1 then ety.MakeArrayType() 
-                             else ety.MakeArrayType rank 
-                          elif ty.IsPointer then ety.MakePointerType() 
-                          elif ty.IsByRef then ety.MakeByRefType()
-                          else ty
-                      else ty
+            for (pt,enclosingGeneratedTypeNames) in providedTypeDefinitions do 
+              match enclosingGeneratedTypeNames with 
+              | None -> 
+                // Filter out the additional TypeProviderTypeAttributes flags
+                let attributes = pt.Attributes &&& ~~~(enum (int32 TypeProviderTypeAttributes.SuppressRelocate))
+                                                &&& ~~~(enum (int32 TypeProviderTypeAttributes.IsErased))
+                // Adjust the attributes - we're codegen'ing as non-nested
+                let attributes = adjustTypeAttributes attributes false 
+                let tb = assemblyMainModule.DefineType(name=pt.FullName,attr=attributes) 
+                pt.SetAssembly null
+                typeMap.[pt] <- tb
+                typeMembers tb pt 
+              | Some ns -> 
+                let otb,_ = 
+                    ((None,""),ns) ||> List.fold (fun (otb:TypeBuilder option,fullName) n -> 
+                        let fullName = if fullName = "" then n else fullName + "." + n
+                        let priorType = if typeMapExtra.ContainsKey(fullName) then Some typeMapExtra.[fullName]  else None
+                        let tb = 
+                            match priorType with 
+                            | Some tbb -> tbb 
+                            | None ->
+                            // OK, the implied nested type is not defined, define it now
+                            let attributes = 
+                                  TypeAttributes.Public ||| 
+                                  TypeAttributes.Class ||| 
+                                  TypeAttributes.Sealed 
+                            // Filter out the additional TypeProviderTypeAttributes flags
+                            let attributes = adjustTypeAttributes attributes otb.IsSome
+                            let tb = 
+                                match otb with 
+                                | None -> assemblyMainModule.DefineType(name=n,attr=attributes) 
+                                | Some (otb:TypeBuilder) -> otb.DefineNestedType(name=n,attr=attributes)
+                            typeMapExtra.[fullName] <- tb
+                            tb
+                        (Some tb, fullName))
+                nestedType otb.Value pt
+        end
+        let rec convType (ty:Type) = 
+            match ty with 
+            | :? ProvidedTypeDefinition as ptd ->   
+                if typeMap.ContainsKey ptd then typeMap.[ptd] :> Type else ty
+            | _ -> 
+                if ty.IsGenericType then ty.GetGenericTypeDefinition().MakeGenericType (Array.map convType (ty.GetGenericArguments()))
+                elif ty.HasElementType then 
+                    let ety = convType (ty.GetElementType()) 
+                    if ty.IsArray then 
+                        let rank = ty.GetArrayRank()
+                        if rank = 1 then ety.MakeArrayType() 
+                        else ety.MakeArrayType rank 
+                    elif ty.IsPointer then ety.MakePointerType() 
+                    elif ty.IsByRef then ety.MakeByRefType()
+                    else ty
+                else ty
 
-              let ctorMap = Dictionary<ProvidedConstructor, ConstructorBuilder>(HashIdentity.Reference)
-              let methMap = Dictionary<ProvidedMethod, MethodBuilder>(HashIdentity.Reference)
+        let ctorMap = Dictionary<ProvidedConstructor, ConstructorBuilder>(HashIdentity.Reference)
+        let methMap = Dictionary<ProvidedMethod, MethodBuilder>(HashIdentity.Reference)
+        let fieldMap = Dictionary<ProvidedField, FieldBuilder>(HashIdentity.Reference)
 
-              let iterateTypes f = 
-                  let rec typeMembers (ptd : ProvidedTypeDefinition) = 
-                      let tb = typeMap.[ptd] 
-                      f tb ptd
-                      for ntd in ptd.GetNestedTypes(BindingFlags.Public ||| BindingFlags.NonPublic) do
-                          nestedType ntd
+        let iterateTypes f = 
+            let rec typeMembers (ptd : ProvidedTypeDefinition) = 
+                let tb = typeMap.[ptd] 
+                f tb (Some ptd)
+                for ntd in ptd.GetNestedTypes(ALL) do
+                    nestedType ntd
 
-                  and nestedType (ntd : Type) = 
-                      match ntd with 
-                      | :? ProvidedTypeDefinition as pntd -> typeMembers pntd
-                      | _ -> ()
+            and nestedType (ntd : Type) = 
+                match ntd with 
+                | :? ProvidedTypeDefinition as pntd -> typeMembers pntd
+                | _ -> ()
                      
-                  for td in typeDefinitions do 
-                      typeMembers td 
+            for (pt,enclosingGeneratedTypeNames) in providedTypeDefinitions do 
+              match enclosingGeneratedTypeNames with 
+              | None -> 
+                typeMembers pt 
+              | Some ns -> 
+                let _fullName  = 
+                    ("",ns) ||> List.fold (fun fullName n -> 
+                        let fullName = if fullName = "" then n else fullName + "." + n
+                        f typeMapExtra.[fullName] None
+                        fullName)
+                nestedType pt
+        
+        
+        // phase 1b - emit base types
+        iterateTypes (fun tb ptd -> 
+            match ptd with 
+            | None -> ()
+            | Some ptd -> 
+            match ptd.BaseType with null -> () | bt -> tb.SetParent(convType bt))
 
-              // phase 2 - emit member definitions
-              iterateTypes (fun tb ptd -> 
-                  let defineMeth (minfo:MethodInfo) = 
-                      match minfo with 
-                      | :? ProvidedMethod as pminfo when not (methMap.ContainsKey pminfo)  -> 
-                          let mb = tb.DefineMethod(minfo.Name, minfo.Attributes, convType minfo.ReturnType, [| for p in minfo.GetParameters() -> convType p.ParameterType |])
-                          //, CallingConventions.Standard, [| for p in cinfo.GetParameters() -> convType p.ParameterType |])
-                          methMap.[pminfo] <- mb
-                      | _ -> () 
-                  for cinfo in ptd.GetConstructors(BindingFlags.Public ||| BindingFlags.NonPublic) do
-                      match cinfo with 
-                      | :? ProvidedConstructor as pcinfo when not (ctorMap.ContainsKey pcinfo)  -> 
-                          let cb = tb.DefineConstructor(cinfo.Attributes, CallingConventions.Standard, [| for p in cinfo.GetParameters() -> convType p.ParameterType |])
-                          ctorMap.[pcinfo] <- cb
-                      | _ -> () 
+        let defineCustomAttrs f (cattrs: IList<CustomAttributeData>) = 
+            for attr in cattrs do
+                let constructorArgs = [ for x in attr.ConstructorArguments -> x.Value ]
+                let namedProps,namedPropVals = [ for x in attr.NamedArguments do match x.MemberInfo with :? PropertyInfo as pi -> yield (pi, x.TypedValue.Value) | _ -> () ] |> List.unzip
+                let namedFields,namedFieldVals = [ for x in attr.NamedArguments do match x.MemberInfo with :? FieldInfo as pi -> yield (pi, x.TypedValue.Value) | _ -> () ] |> List.unzip
+                let cab = CustomAttributeBuilder(attr.Constructor, Array.ofList constructorArgs, Array.ofList namedProps, Array.ofList namedPropVals, Array.ofList namedFields, Array.ofList namedFieldVals)
+                f cab
+
+        // phase 2 - emit member definitions
+        iterateTypes (fun tb ptd -> 
+            match ptd with 
+            | None -> ()
+            | Some ptd -> 
+            for cinfo in ptd.GetConstructors(ALL) do
+                match cinfo with 
+                | :? ProvidedConstructor as pcinfo when not (ctorMap.ContainsKey pcinfo)  ->
+                    let cb =
+                        if pcinfo.IsTypeInitializer then
+                            if (cinfo.GetParameters()).Length <> 0 then failwith "Type initializer should not have parameters"
+                            tb.DefineTypeInitializer()
+                        else 
+                            let cb = tb.DefineConstructor(cinfo.Attributes, CallingConventions.Standard, [| for p in cinfo.GetParameters() -> convType p.ParameterType |])
+                            for (i,p) in cinfo.GetParameters() |> Seq.mapi (fun i x -> (i,x)) do
+                                cb.DefineParameter(i+1, ParameterAttributes.None, p.Name) |> ignore
+                            cb
+                    ctorMap.[pcinfo] <- cb
+                | _ -> () 
                     
-                  for minfo in ptd.GetMethods(BindingFlags.Public ||| BindingFlags.NonPublic) do
-                      defineMeth minfo
+            for finfo in ptd.GetFields(ALL) do
+                match finfo with 
+                | :? ProvidedField as pfinfo when not (fieldMap.ContainsKey pfinfo)  -> 
+                    let fb = tb.DefineField(finfo.Name, convType finfo.FieldType, finfo.Attributes)
+                    let cattr = pfinfo.GetCustomAttributesDataImpl() 
+                    defineCustomAttrs fb.SetCustomAttribute cattr
+                    fieldMap.[pfinfo] <- fb
+                | _ -> () 
+            for minfo in ptd.GetMethods(ALL) do
+                match minfo with 
+                | :? ProvidedMethod as pminfo when not (methMap.ContainsKey pminfo)  -> 
+                    let mb = tb.DefineMethod(minfo.Name, minfo.Attributes, convType minfo.ReturnType, [| for p in minfo.GetParameters() -> convType p.ParameterType |])
+                    for (i,p) in minfo.GetParameters() |> Seq.mapi (fun i x -> (i,x)) do
+                        mb.DefineParameter(i+1, ParameterAttributes.None, p.Name) |> ignore
+                    methMap.[pminfo] <- mb
+                | _ -> () 
 
-                  for ityp in ptd.GetInterfaceImplementations() do
-                      tb.AddInterfaceImplementation ityp)
+            for ityp in ptd.GetInterfaceImplementations() do
+                tb.AddInterfaceImplementation ityp)
 
-              // phase 3 - emit member code
-              iterateTypes (fun  tb ptd -> 
-                  // Allow at most one constructor, and use its arguments as the fields of the type
-                  let ctorArgs, ctorInfoOpt =
-                      match ptd.GetConstructors(BindingFlags.Public ||| BindingFlags.NonPublic) |> Seq.toList with 
-                      | [] -> [], None
-                      | [ :? ProvidedConstructor as pcinfo ] -> [ for p in pcinfo.GetParameters() -> p ], Some pcinfo
-                      | _ -> failwith "at most one constructor allowed"
-                  let ctorArgsAsFields = [ for ctorArg in ctorArgs -> tb.DefineField(ctorArg.Name, convType ctorArg.ParameterType, FieldAttributes.Private) ]
+        // phase 3 - emit member code
+        iterateTypes (fun  tb ptd -> 
+            match ptd with 
+            | None -> ()
+            | Some ptd -> 
+            let cattr = ptd.GetCustomAttributesDataImpl() 
+            defineCustomAttrs tb.SetCustomAttribute cattr
+            // Allow at most one constructor, and use its arguments as the fields of the type
+            let ctors =
+                ptd.GetConstructors(ALL) // exclude type initializer
+                |> Seq.choose (function :? ProvidedConstructor as pcinfo when not pcinfo.IsTypeInitializer -> Some pcinfo | _ -> None) 
+                |> Seq.toList
+            let implictCtorArgs =
+                match ctors  |> List.filter (fun x -> x.IsImplicitCtor)  with
+                | [] -> []
+                | [ pcinfo ] -> [ for p in pcinfo.GetParameters() -> p ]
+                | _ -> failwith "at most one implicit constructor allowed"
 
-                  // Emit the constructor (if any)
-                  match ctorInfoOpt with 
-                  | None -> ()
-                  | Some pcinfo -> 
+            let implicitCtorArgsAsFields = 
+                [ for ctorArg in implictCtorArgs -> 
+                      tb.DefineField(ctorArg.Name, convType ctorArg.ParameterType, FieldAttributes.Private) ]
+            
+            let rec emitLambda(callSiteIlg : ILGenerator, v : Quotations.Var, body : Quotations.Expr, freeVars : seq<Quotations.Var>, locals : Dictionary<_, LocalBuilder>, parameters) =
+                let lambda = assemblyMainModule.DefineType(uniqueLambdaTypeName(), TypeAttributes.Class)
+                let baseType = typedefof<FSharpFunc<_, _>>.MakeGenericType(v.Type, body.Type)
+                lambda.SetParent(baseType)
+                let ctor = lambda.DefineDefaultConstructor(MethodAttributes.Public)
+                let decl = baseType.GetMethod "Invoke"
+                let paramTypes = [| for p in decl.GetParameters() -> p.ParameterType |]
+                let invoke = lambda.DefineMethod("Invoke", MethodAttributes.Virtual ||| MethodAttributes.Final ||| MethodAttributes.Public, decl.ReturnType, paramTypes)
+                lambda.DefineMethodOverride(invoke, decl)
+
+                // promote free vars to fields
+                let fields = ResizeArray()
+                for v in freeVars do
+                    let f = lambda.DefineField(v.Name, v.Type, FieldAttributes.Assembly)
+                    fields.Add(v, f)
+
+                let copyOfLocals = Dictionary()
                 
-                      assert ctorMap.ContainsKey pcinfo
-                      let cb = ctorMap.[pcinfo]
-                      let ilg = cb.GetILGenerator()
-                      ilg.Emit(OpCodes.Ldarg_0)
-                      let minfo = typeof<obj>.GetConstructor [| |]
-                      ilg.Emit(OpCodes.Call,minfo)
-                      for ctorArgsAsFieldIdx,ctorArgsAsField in List.mapi (fun i x -> (i,x)) ctorArgsAsFields do 
-                          ilg.Emit(OpCodes.Ldarg_0)
-                          ilg.Emit(OpCodes.Ldarg, ctorArgsAsFieldIdx+1)
-                          ilg.Emit(OpCodes.Stfld, ctorArgsAsField)
-                    
-                      ilg.Emit(OpCodes.Ret)
-                    
-                  // Emit the methods
-                  let emitMethod (minfo:MethodInfo) = 
-                    match minfo with 
-                    | :? ProvidedMethod as pminfo   -> 
-                      let mb = methMap.[pminfo]
-                      let ilg = mb.GetILGenerator()
-                      let pop () = ilg.Emit(OpCodes.Pop)
+                let ilg = invoke.GetILGenerator()
+                for (v, f) in fields do
+                    let l = ilg.DeclareLocal(v.Type)
+                    ilg.Emit(OpCodes.Ldarg_0)
+                    ilg.Emit(OpCodes.Ldfld, f)
+                    ilg.Emit(OpCodes.Stloc, l)
+                    copyOfLocals.[v] <- l
 
-                      let parameterVars = 
-                          [| if not pminfo.IsStatic then 
-                                 yield Quotations.Var("this", pminfo.DeclaringType)
-                             for p in pminfo.GetParameters() do 
-                                 yield Quotations.Var(p.Name, p.ParameterType) |]
-                      let parameters = 
-                          [| for v in parameterVars -> Quotations.Expr.Var v |]
-                      let linqCode = pminfo.InvokeCodeInternal parameters
-                      let locals = Dictionary<Quotations.Var,LocalBuilder>()
-                      //printfn "Emitting linqCode for %s::%s, code = %s" pminfo.DeclaringType.FullName pminfo.Name (try linqCode.ToString() with _ -> "<error>")
+                let expectedState = if (invoke.ReturnType = typeof<System.Void>) then ExpectedStackState.Empty else ExpectedStackState.Value
+                emitExpr (ilg, copyOfLocals, [| Quotations.Var("this", lambda); v|]) expectedState body
+                ilg.Emit(OpCodes.Ret) 
 
-                      /// emits given expression to corresponding IL
-                      /// callerDontNeedResult - if true then caller will not use result of this expression so it needs to be discarded
-                      let rec emit (callerDontNeedResult : bool) (expr: Quotations.Expr) = 
-                          match expr with 
-                          | Quotations.Patterns.Var v -> 
-                              if callerDontNeedResult then ()
-                              else
-                              let methIdx = parameterVars |> Array.tryFindIndex (fun p -> p = v) 
-                              match methIdx with 
-                              | Some idx -> ilg.Emit(OpCodes.Ldarg, idx)
-                              | None -> 
-                              let ctorArgFieldOpt = ctorArgsAsFields |> List.tryFind (fun f -> f.Name = v.Name) 
-                              match ctorArgFieldOpt with 
-                              | Some ctorArgField -> 
-                                  ilg.Emit(OpCodes.Ldarg_0)
-                                  ilg.Emit(OpCodes.Ldfld, ctorArgField)
-                              | None -> 
-                              match locals.TryGetValue v with 
-                              | true, localBuilder -> 
-                                  ilg.Emit(OpCodes.Ldloc, localBuilder.LocalIndex)
-                              | false, _ -> 
-                                  failwith "unknown parameter/field"
-                          | Quotations.Patterns.Coerce (arg,ty) -> 
-                              if callerDontNeedResult then ()
-                              else
-                              emit false arg
-                              ilg.Emit(OpCodes.Castclass , convType ty)
-                          | Quotations.Patterns.Call (objOpt,meth,args) -> 
-                              match objOpt with None -> () | Some e -> emit false e
-                              for pe in args do 
-                                  emit false pe
-                              let meth = match meth with :? ProvidedMethod as pm when methMap.ContainsKey pm -> methMap.[pm] :> MethodInfo | m -> m
-                              ilg.Emit((if meth.IsAbstract || meth.IsVirtual then  OpCodes.Callvirt else OpCodes.Call), meth)
-                              let returnTypeIsVoid = meth.ReturnType = typeof<System.Void>
-                              match returnTypeIsVoid, callerDontNeedResult with
-                              | false, true -> 
-                                    // method produced something, but we don't need it
-                                    pop()
-                              | true, false when expr.Type = typeof<unit> -> 
-                                    // if we need result and method produce void and result should be unit - push null as unit value on stack
-                                    ilg.Emit(OpCodes.Ldnull)
-                              | _ -> ()
+                let ty = lambda.CreateType()
 
-                          | Quotations.Patterns.NewObject (ctor,args) -> 
-                              for pe in args do 
-                                  emit false pe
-                              let meth = match ctor with :? ProvidedConstructor as pc when ctorMap.ContainsKey pc -> ctorMap.[pc] :> ConstructorInfo | c -> c
-                              ilg.Emit(OpCodes.Newobj, meth)
-                              if callerDontNeedResult then pop()
+                callSiteIlg.Emit(OpCodes.Newobj, ctor)
+                for (v, f) in fields do
+                    callSiteIlg.Emit(OpCodes.Dup)
+                    match locals.TryGetValue v with
+                    | true, loc -> 
+                        callSiteIlg.Emit(OpCodes.Ldloc, loc)
+                    | false, _ -> 
+                        let index = parameters |> Array.findIndex ((=) v)
+                        callSiteIlg.Emit(OpCodes.Ldarg, index)
+                    callSiteIlg.Emit(OpCodes.Stfld, f)
 
-                          | Quotations.Patterns.Value (obj, _ty) -> 
-                              let rec emitC (v:obj) = 
-                                  match v with 
-                                  | :? string as x -> ilg.Emit(OpCodes.Ldstr, x)
-                                  | :? int8 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
-                                  | :? uint8 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 (int8 x))
-                                  | :? int16 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
-                                  | :? uint16 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 (int16 x))
-                                  | :? int32 as x -> ilg.Emit(OpCodes.Ldc_I4, x)
-                                  | :? uint32 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
-                                  | :? int64 as x -> ilg.Emit(OpCodes.Ldc_I8, x)
-                                  | :? uint64 as x -> ilg.Emit(OpCodes.Ldc_I8, int64 x)
-                                  | :? char as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
-                                  | :? bool as x -> ilg.Emit(OpCodes.Ldc_I4, if x then 1 else 0)
-                                  | :? System.Enum as x when x.GetType().GetEnumUnderlyingType() = typeof<int32> -> ilg.Emit(OpCodes.Ldc_I4, unbox<int32> v)
-                                  | null -> ilg.Emit(OpCodes.Ldnull)
-                                  | _ -> failwithf "unknown constant '%A' in generated method" v
-                              if callerDontNeedResult then ()
-                              else emitC obj
-                          | Quotations.Patterns.Let(v,e,b) -> 
-                              let lb = ilg.DeclareLocal v.Type
-                              locals.Add (v, lb) 
-                              emit false e
-                              ilg.Emit(OpCodes.Stloc, lb.LocalIndex)
-                              emit callerDontNeedResult b
+            and emitExpr (ilg: ILGenerator, locals:Dictionary<Quotations.Var,LocalBuilder>, parameterVars) expectedState expr = 
+                let pop () = ilg.Emit(OpCodes.Pop)
+                let popIfEmptyExpected s = if isEmpty s then pop()
+                let emitConvIfNecessary t1 = 
+                    if t1 = typeof<int16> then
+                        ilg.Emit(OpCodes.Conv_I2)
+                    elif t1 = typeof<uint16> then
+                        ilg.Emit(OpCodes.Conv_U2)
+                    elif t1 = typeof<sbyte> then
+                        ilg.Emit(OpCodes.Conv_I1)
+                    elif t1 = typeof<byte> then
+                        ilg.Emit(OpCodes.Conv_U1)
+                /// emits given expression to corresponding IL
+                let rec emit (expectedState : ExpectedStackState) (expr: Quotations.Expr) = 
+                    match expr with 
+                    | Quotations.Patterns.ForIntegerRangeLoop(loopVar, first, last, body) ->
+                      // for(loopVar = first..last) body
+                      let lb = 
+                          match locals.TryGetValue loopVar with
+                          | true, lb -> lb
+                          | false, _ ->
+                              let lb = ilg.DeclareLocal(convType loopVar.Type)
+                              locals.Add(loopVar, lb)
+                              lb
+
+                      // loopVar = first
+                      emit ExpectedStackState.Value first
+                      ilg.Emit(OpCodes.Stloc, lb)
+
+                      let before = ilg.DefineLabel()
+                      let after = ilg.DefineLabel()
+
+                      ilg.MarkLabel before
+                      ilg.Emit(OpCodes.Ldloc, lb)
+                            
+                      emit ExpectedStackState.Value last
+                      ilg.Emit(OpCodes.Bgt, after)
+
+                      emit ExpectedStackState.Empty body
+
+                      // loopVar++
+                      ilg.Emit(OpCodes.Ldloc, lb)
+                      ilg.Emit(OpCodes.Ldc_I4_1)
+                      ilg.Emit(OpCodes.Add)
+                      ilg.Emit(OpCodes.Stloc, lb)
+
+                      ilg.Emit(OpCodes.Br, before)
+                      ilg.MarkLabel(after)
+
+                    | Quotations.Patterns.NewArray(elementTy, elements) ->
+                      ilg.Emit(OpCodes.Ldc_I4, List.length elements)
+                      ilg.Emit(OpCodes.Newarr, convType elementTy)
+
+                      elements 
+                      |> List.iteri (fun i el ->
+                          ilg.Emit(OpCodes.Dup)
+                          ilg.Emit(OpCodes.Ldc_I4, i)
+                          emit ExpectedStackState.Value el
+                          ilg.Emit(OpCodes.Stelem, convType elementTy)
+                          )
+
+                      popIfEmptyExpected expectedState
+
+                    | Quotations.Patterns.WhileLoop(cond, body) ->
+                      let before = ilg.DefineLabel()
+                      let after = ilg.DefineLabel()
+
+                      ilg.MarkLabel before
+                      emit ExpectedStackState.Value cond
+                      ilg.Emit(OpCodes.Brfalse, after)
+                      emit ExpectedStackState.Empty body
+                      ilg.Emit(OpCodes.Br, before)
+
+                      ilg.MarkLabel after
+
+                    | Quotations.Patterns.Var v -> 
+                        if isEmpty expectedState then () else
+                        let methIdx = parameterVars |> Array.tryFindIndex (fun p -> p = v) 
+                        match methIdx with 
+                        | Some idx -> 
+                            ilg.Emit((if isAddress expectedState then OpCodes.Ldarga else OpCodes.Ldarg), idx)
+                        | None -> 
+                        let implicitCtorArgFieldOpt = implicitCtorArgsAsFields |> List.tryFind (fun f -> f.Name = v.Name) 
+                        match implicitCtorArgFieldOpt with 
+                        | Some ctorArgField -> 
+                            ilg.Emit(OpCodes.Ldarg_0)
+                            ilg.Emit(OpCodes.Ldfld, ctorArgField)
+                        | None -> 
+                        match locals.TryGetValue v with 
+                        | true, localBuilder -> 
+                            ilg.Emit((if isAddress expectedState  then OpCodes.Ldloca else OpCodes.Ldloc), localBuilder.LocalIndex)
+                        | false, _ -> 
+                            failwith "unknown parameter/field"
+
+                    | Quotations.Patterns.Coerce (arg,ty) -> 
+                        // castClass may lead to observable side-effects - InvalidCastException
+                        emit ExpectedStackState.Value arg
+                        let argTy = convType arg.Type
+                        let targetTy = convType ty
+                        if argTy.IsValueType && not targetTy.IsValueType then
+                          ilg.Emit(OpCodes.Box, argTy)
+                        elif not argTy.IsValueType && targetTy.IsValueType then
+                          ilg.Emit(OpCodes.Unbox_Any, targetTy)
+                        // emit castclass if 
+                        // - targettype is not obj (assume this is always possible for ref types)
+                        // AND 
+                        // - HACK: targettype is TypeBuilderInstantiationType 
+                        //   (its implementation of IsAssignableFrom raises NotSupportedException so it will be safer to always emit castclass)
+                        // OR
+                        // - not (argTy :> targetTy)
+                        elif targetTy <> typeof<obj> && (Misc.TypeBuilderInstantiationType.Equals(targetTy.GetType()) || not (targetTy.IsAssignableFrom(argTy))) then
+                          ilg.Emit(OpCodes.Castclass, targetTy)
                               
-                          | Quotations.Patterns.Sequential(e1, e2) ->
-                              emit true e1
-                              emit callerDontNeedResult e2                          
-                          | Quotations.Patterns.IfThenElse(cond, ifTrue, ifFalse) ->
-                              let ifFalseLabel = ilg.DefineLabel()
-                              let endLabel = ilg.DefineLabel()
+                        popIfEmptyExpected expectedState
+                    | Quotations.DerivedPatterns.SpecificCall <@ (-) @>(None, [t1; t2; t3], [a1; a2]) ->
+                        assert(t1 = t2)
+                        emit ExpectedStackState.Value a1
+                        emit ExpectedStackState.Value a2
+                        if t1 = typeof<decimal> then
+                            ilg.Emit(OpCodes.Call, typeof<decimal>.GetMethod "op_Subtraction")
+                        else
+                            ilg.Emit(OpCodes.Sub)
+                            emitConvIfNecessary t1
 
-                              emit false cond
+                        popIfEmptyExpected expectedState
 
-                              ilg.Emit(OpCodes.Brfalse, ifFalseLabel)
+                    | Quotations.DerivedPatterns.SpecificCall <@ (/) @> (None, [t1; t2; t3], [a1; a2]) ->
+                        assert (t1 = t2)
+                        emit ExpectedStackState.Value a1
+                        emit ExpectedStackState.Value a2
+                        if t1 = typeof<decimal> then
+                            ilg.Emit(OpCodes.Call, typeof<decimal>.GetMethod "op_Division")
+                        else
+                            match Type.GetTypeCode t1 with
+                            | TypeCode.UInt32
+                            | TypeCode.UInt64
+                            | TypeCode.UInt16
+                            | TypeCode.Byte
+                            | _ when t1 = typeof<unativeint> -> ilg.Emit (OpCodes.Div_Un)
+                            | _ -> ilg.Emit(OpCodes.Div)
 
-                              emit callerDontNeedResult ifTrue
-                              ilg.Emit(OpCodes.Br, endLabel)
+                            emitConvIfNecessary t1
 
-                              ilg.MarkLabel(ifFalseLabel)
-                              emit callerDontNeedResult ifFalse
+                        popIfEmptyExpected expectedState
 
-                              ilg.Emit(OpCodes.Nop)
-                              ilg.MarkLabel(endLabel)
+                    | Quotations.DerivedPatterns.SpecificCall <@ int @>(None, [sourceTy], [v]) ->
+                        emit ExpectedStackState.Value v
+                        match Type.GetTypeCode(sourceTy) with
+                        | TypeCode.String -> 
+                            ilg.Emit(OpCodes.Call, Misc.ParseInt32Method)
+                        | TypeCode.Single
+                        | TypeCode.Double
+                        | TypeCode.Int64 
+                        | TypeCode.UInt64
+                        | TypeCode.UInt16
+                        | TypeCode.Char
+                        | TypeCode.Byte
+                        | _ when sourceTy = typeof<nativeint> || sourceTy = typeof<unativeint> ->
+                            ilg.Emit(OpCodes.Conv_I4)
+                        | TypeCode.Int32
+                        | TypeCode.UInt32
+                        | TypeCode.Int16
+                        | TypeCode.SByte -> () // no op
+                        | _ -> failwith "TODO: search for op_Explicit on sourceTy"
 
-                          | Quotations.Patterns.TryWith(body, _filterVar, _filterBody, catchVar, catchBody) ->                                                                                      
+                    | Quotations.DerivedPatterns.SpecificCall <@ LanguagePrimitives.IntrinsicFunctions.GetArray @> (None, [ty], [arr; index]) ->
+                        // observable side-effect - IndexOutOfRangeException
+                        emit ExpectedStackState.Value arr
+                        emit ExpectedStackState.Value index
+                        if isAddress expectedState then
+                            ilg.Emit(OpCodes.Readonly)
+                            ilg.Emit(OpCodes.Ldelema, convType ty)
+                        else
+                            ilg.Emit(OpCodes.Ldelem, convType ty)
+
+                        popIfEmptyExpected expectedState
+
+                    | Quotations.DerivedPatterns.SpecificCall <@ LanguagePrimitives.IntrinsicFunctions.GetArray2D @> (None, _ty, arr::indices)
+                    | Quotations.DerivedPatterns.SpecificCall <@ LanguagePrimitives.IntrinsicFunctions.GetArray3D @> (None, _ty, arr::indices)
+                    | Quotations.DerivedPatterns.SpecificCall <@ LanguagePrimitives.IntrinsicFunctions.GetArray4D @> (None, _ty, arr::indices) ->
                               
-                              let stres, ldres = 
-                                  if callerDontNeedResult then ignore, ignore
-                                  else
-                                    let local = ilg.DeclareLocal body.Type
-                                    let stres = fun () -> ilg.Emit(OpCodes.Stloc, local)
-                                    let ldres = fun () -> ilg.Emit(OpCodes.Ldloc, local)
-                                    stres, ldres
+                        let meth = 
+                          let name = if isAddress expectedState then "Address" else "Get"
+                          arr.Type.GetMethod(name)
 
-                              let exceptionVar = ilg.DeclareLocal(catchVar.Type)
-                              locals.Add(catchVar, exceptionVar)
-
-                              let _exnBlock = ilg.BeginExceptionBlock()
+                        // observable side-effect - IndexOutOfRangeException
+                        emit ExpectedStackState.Value arr
+                        for index in indices do
+                          emit ExpectedStackState.Value index
                               
-                              emit callerDontNeedResult body
-                              stres()
+                        if isAddress expectedState then
+                          ilg.Emit(OpCodes.Readonly)
 
-                              ilg.BeginCatchBlock(catchVar.Type)
-                              ilg.Emit(OpCodes.Stloc, exceptionVar)
-                              emit callerDontNeedResult catchBody
-                              stres()
-                              ilg.EndExceptionBlock()
+                        ilg.Emit(OpCodes.Call, meth)
 
-                              ldres()
+                        popIfEmptyExpected expectedState
 
-                          | Quotations.Patterns.VarSet(v,e) -> 
-                              emit false e
-                              match locals.TryGetValue v with 
-                              | true, localBuilder -> 
-                                  ilg.Emit(OpCodes.Stloc, localBuilder.LocalIndex)
-                              | false, _ -> 
-                                  failwith "unknown parameter/field in assignment. Only assignments to locals are currently supported by TypeProviderEmit"
-                          | n -> 
-                              failwith (sprintf "unknown expression '%A' in generated method" n)
+                    | Quotations.Patterns.FieldGet (objOpt,field) -> 
+                        match objOpt with 
+                        | None -> () 
+                        | Some e -> 
+                          let s = if e.Type.IsValueType then ExpectedStackState.Address else ExpectedStackState.Value
+                          emit s e
+                        let field = match field with :? ProvidedField as pf when fieldMap.ContainsKey pf -> fieldMap.[pf] :> FieldInfo | m -> m
+                        if field.IsStatic then 
+                            ilg.Emit(OpCodes.Ldsfld, field)
+                        else
+                            ilg.Emit(OpCodes.Ldfld, field)
 
-                      let callerDontNeedResult = (minfo.ReturnType = typeof<System.Void>)
-                      emit callerDontNeedResult linqCode
-                      ilg.Emit OpCodes.Ret
-                    | _ -> ()
+                    | Quotations.Patterns.FieldSet (objOpt,field,v) -> 
+                        match objOpt with 
+                        | None -> () 
+                        | Some e -> 
+                          let s = if e.Type.IsValueType then ExpectedStackState.Address else ExpectedStackState.Value
+                          emit s e
+                        emit ExpectedStackState.Value v
+                        let field = match field with :? ProvidedField as pf when fieldMap.ContainsKey pf -> fieldMap.[pf] :> FieldInfo | m -> m
+                        if field.IsStatic then 
+                            ilg.Emit(OpCodes.Stsfld, field)
+                        else
+                            ilg.Emit(OpCodes.Stfld, field)
+                    | Quotations.Patterns.Call (objOpt,meth,args) -> 
+                        match objOpt with 
+                        | None -> () 
+                        | Some e -> 
+                          let s = if e.Type.IsValueType then ExpectedStackState.Address else ExpectedStackState.Value
+                          emit s e
+                        for pe in args do 
+                            emit ExpectedStackState.Value pe
+                        let getMeth (m:MethodInfo) = match m with :? ProvidedMethod as pm when methMap.ContainsKey pm -> methMap.[pm] :> MethodInfo | m -> m
+                        // Handle the case where this is a generic method instantiated at a type being compiled
+                        let mappedMeth = 
+                            if meth.IsGenericMethod then 
+                                let args = meth.GetGenericArguments() |> Array.map convType
+                                let gmd = meth.GetGenericMethodDefinition() |> getMeth
+                                gmd.GetGenericMethodDefinition().MakeGenericMethod args
+                            elif meth.DeclaringType.IsGenericType then 
+                                let gdty = convType (meth.DeclaringType.GetGenericTypeDefinition())
+                                let gdtym = gdty.GetMethods() |> Seq.find (fun x -> x.Name = meth.Name)
+                                assert (gdtym <> null) // ?? will never happen - if method is not found - KeyNotFoundException will be raised
+                                let dtym =
+                                    match convType meth.DeclaringType with
+                                    | :? TypeBuilder as dty -> TypeBuilder.GetMethod(dty, gdtym)
+                                    | dty -> MethodBase.GetMethodFromHandle(meth.MethodHandle, dty.TypeHandle) :?> _
+                                
+                                assert (dtym <> null)
+                                dtym
+                            else
+                                getMeth meth
+                        match objOpt with 
+                        | Some obj when mappedMeth.IsAbstract || mappedMeth.IsVirtual  ->
+                            if obj.Type.IsValueType then ilg.Emit(OpCodes.Constrained, convType obj.Type)
+                            ilg.Emit(OpCodes.Callvirt, mappedMeth)
+                        | _ ->
+                            ilg.Emit(OpCodes.Call, mappedMeth)
+
+                        let returnTypeIsVoid = mappedMeth.ReturnType = typeof<System.Void>
+                        match returnTypeIsVoid, (isEmpty expectedState) with
+                        | false, true -> 
+                              // method produced something, but we don't need it
+                              pop()
+                        | true, false when expr.Type = typeof<unit> -> 
+                              // if we need result and method produce void and result should be unit - push null as unit value on stack
+                              ilg.Emit(OpCodes.Ldnull)
+                        | _ -> ()
+
+                    | Quotations.Patterns.NewObject (ctor,args) -> 
+                        for pe in args do 
+                            emit ExpectedStackState.Value pe
+                        let meth = match ctor with :? ProvidedConstructor as pc when ctorMap.ContainsKey pc -> ctorMap.[pc] :> ConstructorInfo | c -> c
+                        ilg.Emit(OpCodes.Newobj, meth)
+                              
+                        popIfEmptyExpected expectedState                              
+
+                    | Quotations.Patterns.Value (obj, _ty) -> 
+                        let rec emitC (v:obj) = 
+                            match v with 
+                            | :? string as x -> ilg.Emit(OpCodes.Ldstr, x)
+                            | :? int8 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
+                            | :? uint8 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 (int8 x))
+                            | :? int16 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
+                            | :? uint16 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 (int16 x))
+                            | :? int32 as x -> ilg.Emit(OpCodes.Ldc_I4, x)
+                            | :? uint32 as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
+                            | :? int64 as x -> ilg.Emit(OpCodes.Ldc_I8, x)
+                            | :? uint64 as x -> ilg.Emit(OpCodes.Ldc_I8, int64 x)
+                            | :? char as x -> ilg.Emit(OpCodes.Ldc_I4, int32 x)
+                            | :? bool as x -> ilg.Emit(OpCodes.Ldc_I4, if x then 1 else 0)
+                            | :? float32 as x -> ilg.Emit(OpCodes.Ldc_R4, x)
+                            | :? float as x -> ilg.Emit(OpCodes.Ldc_R8, x)
+#if FX_NO_GET_ENUM_UNDERLYING_TYPE
+#else
+                            | :? System.Enum as x when x.GetType().GetEnumUnderlyingType() = typeof<int32> -> ilg.Emit(OpCodes.Ldc_I4, unbox<int32> v)
+#endif
+                            | :? Type as ty ->
+                                ilg.Emit(OpCodes.Ldtoken, convType ty)
+                                ilg.Emit(OpCodes.Call, Misc.GetTypeFromHandleMethod)
+                            | null -> ilg.Emit(OpCodes.Ldnull)
+                            | _ -> failwithf "unknown constant '%A' in generated method" v
+                        if isEmpty expectedState then ()
+                        else emitC obj
+
+                    | Quotations.Patterns.Let(v,e,b) -> 
+                        let lb = ilg.DeclareLocal (convType v.Type)
+                        locals.Add (v, lb) 
+                        emit ExpectedStackState.Value e
+                        ilg.Emit(OpCodes.Stloc, lb.LocalIndex)
+                        emit expectedState b
+                              
+                    | Quotations.Patterns.Sequential(e1, e2) ->
+                        emit ExpectedStackState.Empty e1
+                        emit expectedState e2                          
+
+                    | Quotations.Patterns.IfThenElse(cond, ifTrue, ifFalse) ->
+                        let ifFalseLabel = ilg.DefineLabel()
+                        let endLabel = ilg.DefineLabel()
+
+                        emit ExpectedStackState.Value cond
+
+                        ilg.Emit(OpCodes.Brfalse, ifFalseLabel)
+
+                        emit expectedState ifTrue
+                        ilg.Emit(OpCodes.Br, endLabel)
+
+                        ilg.MarkLabel(ifFalseLabel)
+                        emit expectedState ifFalse
+
+                        ilg.Emit(OpCodes.Nop)
+                        ilg.MarkLabel(endLabel)
+
+                    | Quotations.Patterns.TryWith(body, _filterVar, _filterBody, catchVar, catchBody) ->                                                                                      
+                              
+                        let stres, ldres = 
+                            if isEmpty expectedState then ignore, ignore
+                            else
+                              let local = ilg.DeclareLocal (convType body.Type)
+                              let stres = fun () -> ilg.Emit(OpCodes.Stloc, local)
+                              let ldres = fun () -> ilg.Emit(OpCodes.Ldloc, local)
+                              stres, ldres
+
+                        let exceptionVar = ilg.DeclareLocal(convType catchVar.Type)
+                        locals.Add(catchVar, exceptionVar)
+
+                        let _exnBlock = ilg.BeginExceptionBlock()
+                              
+                        emit expectedState body
+                        stres()
+
+                        ilg.BeginCatchBlock(convType  catchVar.Type)
+                        ilg.Emit(OpCodes.Stloc, exceptionVar)
+                        emit expectedState catchBody
+                        stres()
+                        ilg.EndExceptionBlock()
+
+                        ldres()
+
+                    | Quotations.Patterns.VarSet(v,e) -> 
+                        emit ExpectedStackState.Value e
+                        match locals.TryGetValue v with 
+                        | true, localBuilder -> 
+                            ilg.Emit(OpCodes.Stloc, localBuilder.LocalIndex)
+                        | false, _ -> 
+                            failwith "unknown parameter/field in assignment. Only assignments to locals are currently supported by TypeProviderEmit"
+                    | Quotations.Patterns.Lambda(v, body) ->
+                        emitLambda(ilg, v, body, expr.GetFreeVars(), locals, parameterVars)
+                        popIfEmptyExpected expectedState
+                    | n -> 
+                        failwith (sprintf "unknown expression '%A' in generated method" n)
+                emit expectedState expr
+
+
+            // Emit the constructor (if any)
+            for pcinfo in ctors do 
+                assert ctorMap.ContainsKey pcinfo
+                let cb = ctorMap.[pcinfo]
+                let cattr = pcinfo.GetCustomAttributesDataImpl() 
+                defineCustomAttrs cb.SetCustomAttribute cattr
+                let ilg = cb.GetILGenerator()
+                ilg.Emit(OpCodes.Ldarg_0)
+                let locals = Dictionary<Quotations.Var,LocalBuilder>()
+                let parameterVars = 
+                    [| yield Quotations.Var("this", pcinfo.DeclaringType)
+                       for p in pcinfo.GetParameters() do 
+                            yield Quotations.Var(p.Name, p.ParameterType) |]
+                let parameters = 
+                    [| for v in parameterVars -> Quotations.Expr.Var v |]
+                match pcinfo.GetBaseConstructorCallInternal true with
+                | None ->  
+                    let cinfo = ptd.BaseType.GetConstructor(BindingFlags.Public ||| BindingFlags.NonPublic ||| BindingFlags.Instance, null, [| |], null)
+                    ilg.Emit(OpCodes.Call,cinfo)
+                | Some f -> 
+                    let (cinfo,argExprs) = f (Array.toList parameters)
+                    for argExpr in argExprs do 
+                        emitExpr (ilg, locals, parameterVars) ExpectedStackState.Value argExpr
+                    ilg.Emit(OpCodes.Call,cinfo)
+
+                if pcinfo.IsImplicitCtor then
+                    for ctorArgsAsFieldIdx,ctorArgsAsField in List.mapi (fun i x -> (i,x)) implicitCtorArgsAsFields do 
+                        ilg.Emit(OpCodes.Ldarg_0)
+                        ilg.Emit(OpCodes.Ldarg, ctorArgsAsFieldIdx+1)
+                        ilg.Emit(OpCodes.Stfld, ctorArgsAsField)
+                else
+                    let code  = pcinfo.GetInvokeCodeInternal true
+                    let code = code parameters
+                    emitExpr (ilg, locals, parameterVars) ExpectedStackState.Empty code
+                ilg.Emit(OpCodes.Ret)
+            
+            match ptd.GetConstructors(ALL) |> Seq.tryPick (function :? ProvidedConstructor as pc when pc.IsTypeInitializer -> Some pc | _ -> None) with
+            | None -> ()
+            | Some pc ->
+                let cb = ctorMap.[pc]
+                let ilg = cb.GetILGenerator()
+                let cattr = pc.GetCustomAttributesDataImpl() 
+                defineCustomAttrs cb.SetCustomAttribute cattr
+                let expr = pc.GetInvokeCodeInternal true [||]
+                emitExpr(ilg, new Dictionary<_, _>(), [||]) ExpectedStackState.Empty expr
+                ilg.Emit OpCodes.Ret
+
+            // Emit the methods
+            for minfo in ptd.GetMethods(ALL) do
+              match minfo with 
+              | :? ProvidedMethod as pminfo   -> 
+                let mb = methMap.[pminfo]
+                let ilg = mb.GetILGenerator()
+                let cattr = pminfo.GetCustomAttributesDataImpl() 
+                defineCustomAttrs mb.SetCustomAttribute cattr
+
+                let parameterVars = 
+                    [| if not pminfo.IsStatic then 
+                            yield Quotations.Var("this", pminfo.DeclaringType)
+                       for p in pminfo.GetParameters() do 
+                            yield Quotations.Var(p.Name, p.ParameterType) |]
+                let parameters = 
+                    [| for v in parameterVars -> Quotations.Expr.Var v |]
+
+                let expr = pminfo.GetInvokeCodeInternal true parameters 
+
+                let locals = Dictionary<Quotations.Var,LocalBuilder>()
+                //printfn "Emitting linqCode for %s::%s, code = %s" pminfo.DeclaringType.FullName pminfo.Name (try linqCode.ToString() with _ -> "<error>")
+
+
+                let expectedState = if (minfo.ReturnType = typeof<System.Void>) then ExpectedStackState.Empty else ExpectedStackState.Value
+                emitExpr (ilg, locals, parameterVars) expectedState expr
+                ilg.Emit OpCodes.Ret
+              | _ -> ()
   
-                  for minfo in ptd.GetMethods(BindingFlags.Public ||| BindingFlags.NonPublic) do
-                      emitMethod minfo
+            for (bodyMethInfo,declMethInfo) in ptd.GetMethodOverrides() do 
+                let bodyMethBuilder = methMap.[bodyMethInfo]
+                tb.DefineMethodOverride(bodyMethBuilder,declMethInfo)
 
-                  for (bodyMethInfo,declMethInfo) in ptd.GetMethodOverrides() do 
-                     let bodyMethBuilder = methMap.[bodyMethInfo]
-                     tb.DefineMethodOverride(bodyMethBuilder,declMethInfo)
+            for evt in ptd.GetEvents(ALL) |> Seq.choose (function :? ProvidedEvent as pe -> Some pe | _ -> None) do
+                let eb = tb.DefineEvent(evt.Name, evt.Attributes, evt.EventHandlerType)
+                defineCustomAttrs eb.SetCustomAttribute (evt.GetCustomAttributesDataImpl())
+                eb.SetAddOnMethod(methMap.[evt.GetAddMethod(true) :?> _])
+                eb.SetRemoveOnMethod(methMap.[evt.GetRemoveMethod(true) :?> _])
+                // TODO: add raiser
+            
+            for pinfo in ptd.GetProperties(ALL) |> Seq.choose (function :? ProvidedProperty as pe -> Some pe | _ -> None) do
+                let pb = tb.DefineProperty(pinfo.Name, pinfo.Attributes, convType pinfo.PropertyType, [| for p in pinfo.GetIndexParameters() -> convType p.ParameterType |])
+                let cattr = pinfo.GetCustomAttributesDataImpl() 
+                defineCustomAttrs pb.SetCustomAttribute cattr
+                if  pinfo.CanRead then 
+                    let minfo = pinfo.GetGetMethod(true)
+                    pb.SetGetMethod (methMap.[minfo :?> ProvidedMethod ])
+                if  pinfo.CanWrite then 
+                    let minfo = pinfo.GetSetMethod(true)
+                    pb.SetSetMethod (methMap.[minfo :?> ProvidedMethod ]))
 
-                  for pinfo in ptd.GetProperties(BindingFlags.Public ||| BindingFlags.NonPublic) do
-                      let pb = tb.DefineProperty(pinfo.Name, pinfo.Attributes, convType pinfo.PropertyType, [| for p in pinfo.GetIndexParameters() -> convType p.ParameterType |])
-                      if  pinfo.CanRead then 
-                          let minfo = pinfo.GetGetMethod(true)
-                          pb.SetGetMethod (methMap.[minfo :?> ProvidedMethod ])
-                      if  pinfo.CanWrite then 
-                          let minfo = pinfo.GetSetMethod(true)
-                          pb.SetSetMethod (methMap.[minfo :?> ProvidedMethod ]))
 
-              // phase 4 - complete types
-              iterateTypes (fun tb _ptd -> tb.CreateType() |> ignore)
+        // phase 4 - complete types
+        iterateTypes (fun tb _ptd -> tb.CreateType() |> ignore)
 
+#if FX_NO_LOCAL_FILESYSTEM
+#else
+        assembly.Save (Path.GetFileName assemblyFileName)
+#endif
 
-              assembly.Save (Path.GetFileName assemblyFileName)
-              let assemblyBytes = File.ReadAllBytes assemblyFileName
-              let assemblyLoadedInMemory = System.Reflection.Assembly.Load(assemblyBytes,null,System.Security.SecurityContextSource.CurrentAppDomain)
-              File.Delete assemblyFileName
+        let assemblyLoadedInMemory = assemblyMainModule.Assembly 
 
-              iterateTypes (fun _tb ptd -> ptd.SetAssembly assemblyLoadedInMemory)
+        iterateTypes (fun _tb ptd -> 
+            match ptd with 
+            | None -> ()
+            | Some ptd -> ptd.SetAssembly assemblyLoadedInMemory)
 
-              match reportAssemblyElements with 
-              | None -> GlobalProvidedAssemblyElementsTable.theTable.Add(assemblyLoadedInMemory, assemblyBytes) 
-              | Some f -> f (assemblyLoadedInMemory, assemblyBytes)
-              assemblyLoadedInMemory
+#if FX_NO_LOCAL_FILESYSTEM
+#else
+    member __.GetFinalBytes() = 
+        let assemblyBytes = File.ReadAllBytes assemblyFileName
+        let _assemblyLoadedInMemory = System.Reflection.Assembly.Load(assemblyBytes,null,System.Security.SecurityContextSource.CurrentAppDomain)
+        //printfn "final bytes in '%s'" assemblyFileName
+        //File.Delete assemblyFileName
+        assemblyBytes
+#endif
 
-        theAssembly <- theElementsLazy
+type ProvidedAssembly(assemblyFileName: string) = 
+    let theTypes = ResizeArray<_>()
+    let assemblyGenerator = AssemblyGenerator(assemblyFileName)
+    let assemblyLazy = 
+        lazy 
+            assemblyGenerator.Generate(theTypes |> Seq.toList)
+            assemblyGenerator.Assembly
+#if FX_NO_LOCAL_FILESYSTEM
+#else
+    let theAssemblyBytesLazy = 
+      lazy
+        assemblyGenerator.GetFinalBytes()
+
+    do
+        GlobalProvidedAssemblyElementsTable.theTable.Add(assemblyGenerator.Assembly, theAssemblyBytesLazy) 
+
+#endif
+
+    let add (providedTypeDefinitions:ProvidedTypeDefinition list, enclosingTypeNames: string list option) = 
+        for pt in providedTypeDefinitions do 
+            if pt.IsErased then invalidOp ("The provided type "+pt.Name+"is marked as erased and cannot be converted to a generated type. Set 'IsErased' to false on the ProvidedTypeDefinition")
+            theTypes.Add(pt,enclosingTypeNames)
+            pt.SetAssemblyLazy assemblyLazy
+
+    member x.AddNestedTypes (providedTypeDefinitions, enclosingTypeNames) = add (providedTypeDefinitions, Some enclosingTypeNames)
+    member x.AddTypes (providedTypeDefinitions) = add (providedTypeDefinitions, None)
+#if FX_NO_LOCAL_FILESYSTEM
+#else
+    static member RegisterGenerated (fileName:string) = 
+        //printfn "registered assembly in '%s'" fileName
+        let assemblyBytes = System.IO.File.ReadAllBytes fileName
+        let assembly = Assembly.Load(assemblyBytes,null,System.Security.SecurityContextSource.CurrentAppDomain)
+        GlobalProvidedAssemblyElementsTable.theTable.Add(assembly, Lazy.CreateFromValue assemblyBytes)
+        assembly
+#endif
 
 
 module Local = 
@@ -1156,12 +2141,17 @@ module Local =
             member __.ResolveTypeName typeName : System.Type = 
                 match types |> Array.tryFind (fun ty -> ty.Name = typeName) with
                 | Some ty -> ty
-                | None    -> let typenames = String.concat "," (types |> Array.map (fun t -> t.Name))
-                             failwith (sprintf "Unknown type '%s' in namespace '%s' (contains %s)" typeName namespaceName typenames)    
+                | None    -> null
+                // let typenames = String.concat "," (types |> Array.map (fun t -> t.Name))
+                //             failwith (sprintf "Unknown type '%s' in namespace '%s' (contains %s)" typeName namespaceName typenames)    
         }
 
 
+#if FX_NO_LOCAL_FILESYSTEM
 type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<ProvidedTypeDefinition>)>) =
+#else
+type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<ProvidedTypeDefinition>)>) as this =
+#endif
     let otherNamespaces = ResizeArray<string * list<ProvidedTypeDefinition>>()
 
     let providedNamespaces = 
@@ -1172,33 +2162,105 @@ type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<Provided
 
     let invalidateE = new Event<EventHandler,EventArgs>()    
 
+#if FX_NO_LOCAL_FILESYSTEM
+#else
+    let probingFolders = ResizeArray()
+    let handler = ResolveEventHandler(fun _ args -> this.ResolveAssembly(args))
+    do AppDomain.CurrentDomain.add_AssemblyResolve handler
+#endif
+
     new (namespaceName:string,types:list<ProvidedTypeDefinition>) = new TypeProviderForNamespaces([(namespaceName,types)])
     new () = new TypeProviderForNamespaces([])
 
-    member __.AddNamespace (namespaceName,types:list<_>) = otherNamespaces.Add (namespaceName,types)
-    member self.Invalidate() = invalidateE.Trigger(self,EventArgs())
+#if FX_NO_LOCAL_FILESYSTEM
     interface System.IDisposable with 
         member x.Dispose() = ()
+#else
+    abstract member ResolveAssembly : args : System.ResolveEventArgs -> Assembly
+    default this.ResolveAssembly(args) = 
+        let expectedName = (AssemblyName(args.Name)).Name + ".dll"
+        let expectedLocationOpt = 
+            probingFolders 
+            |> Seq.map (fun f -> IO.Path.Combine(f, expectedName))
+            |> Seq.tryFind IO.File.Exists
+        match expectedLocationOpt with
+        | Some f -> Assembly.LoadFrom f
+        | None -> null
+
+    member this.RegisterProbingFolder (folder) = 
+        // use GetFullPath to ensure that folder is valid
+        ignore(IO.Path.GetFullPath folder)
+        probingFolders.Add folder
+    member this.RegisterRuntimeAssemblyLocationAsProbingFolder (cfg : Core.CompilerServices.TypeProviderConfig) =  
+        cfg.RuntimeAssembly
+        |> IO.Path.GetDirectoryName
+        |> this.RegisterProbingFolder
+    interface System.IDisposable with 
+        member x.Dispose() = AppDomain.CurrentDomain.remove_AssemblyResolve handler
+#endif
+
+    member __.AddNamespace (namespaceName,types:list<_>) = otherNamespaces.Add (namespaceName,types)
+    // FSharp.Data addition: this method is used by Debug.fs
+    member __.Namespaces = Seq.readonly otherNamespaces
+    member self.Invalidate() = invalidateE.Trigger(self,EventArgs())
     interface ITypeProvider with
         [<CLIEvent>]
         override this.Invalidate = invalidateE.Publish
         override this.GetNamespaces() = Array.copy providedNamespaces.Value
-        member __.GetInvokerExpression(methodBase, parameters) = 
-            match methodBase with
-            | :? ProvidedMethod as m when (match methodBase.DeclaringType with :? ProvidedTypeDefinition as pt -> pt.IsErased | _ -> true) -> 
-                m.InvokeCodeInternal parameters
-            | :? ProvidedConstructor as m when (match methodBase.DeclaringType with :? ProvidedTypeDefinition as pt -> pt.IsErased | _ -> true) -> 
-                m.InvokeCodeInternal parameters
-            // Otherwise, assume this is a generative assembly and just emit a call to the constructor or method
-            | :?  ConstructorInfo as cinfo ->  
-                Quotations.Expr.NewObject(cinfo, Array.toList parameters) 
-            | :? System.Reflection.MethodInfo as minfo ->  
-                if minfo.IsStatic then 
-                    Quotations.Expr.Call(minfo, Array.toList parameters) 
-                else
-                    Quotations.Expr.Call(parameters.[0], minfo, Array.toList parameters.[1..])
-            | _ -> failwith ("TypeProviderForNamespaces.GetInvokerExpression: not a ProvidedMethod/ProvidedConstructor/ConstructorInfo/MethodInfo, name=" + methodBase.Name + " class=" + methodBase.GetType().FullName)
+        member __.GetInvokerExpression(methodBase, parameters) =
+            let rec getInvokerExpression (methodBase : MethodBase) parameters =
+                match methodBase with
+                | :? ProvidedMethod as m when (match methodBase.DeclaringType with :? ProvidedTypeDefinition as pt -> pt.IsErased | _ -> true) ->
+                    m.GetInvokeCodeInternal false parameters
+                    |> expand
+                | :? ProvidedConstructor as m when (match methodBase.DeclaringType with :? ProvidedTypeDefinition as pt -> pt.IsErased | _ -> true) -> 
+                    m.GetInvokeCodeInternal false parameters
+                    |> expand
+                // Otherwise, assume this is a generative assembly and just emit a call to the constructor or method
+                | :?  ConstructorInfo as cinfo ->  
+                    Quotations.Expr.NewObject(cinfo, Array.toList parameters) 
+                | :? System.Reflection.MethodInfo as minfo ->  
+                    if minfo.IsStatic then 
+                        Quotations.Expr.Call(minfo, Array.toList parameters) 
+                    else
+                        Quotations.Expr.Call(parameters.[0], minfo, Array.toList parameters.[1..])
+                | _ -> failwith ("TypeProviderForNamespaces.GetInvokerExpression: not a ProvidedMethod/ProvidedConstructor/ConstructorInfo/MethodInfo, name=" + methodBase.Name + " class=" + methodBase.GetType().FullName)
+            and expand expr = 
+                match expr with
+                | Quotations.Patterns.NewObject(ctor, args) -> getInvokerExpression ctor [| for arg in args -> expand arg|]
+                | Quotations.Patterns.Call(inst, mi, args) ->
+                    let args = 
+                        [|
+                            match inst with
+                            | Some inst -> yield expand inst
+                            | _ -> ()
+                            yield! List.map expand args
+                        |]
+                    getInvokerExpression mi args
+                | Quotations.ExprShape.ShapeVar v -> Quotations.Expr.Var v
+                | Quotations.ExprShape.ShapeLambda(v, body) -> Quotations.Expr.Lambda(v, expand body)
+                | Quotations.ExprShape.ShapeCombination(shape, args) -> Quotations.ExprShape.RebuildShapeCombination(shape, List.map expand args)
+            getInvokerExpression methodBase parameters
+#if FX_NO_CUSTOMATTRIBUTEDATA
 
+        member __.GetMemberCustomAttributesData(methodBase) = 
+            match methodBase with
+            | :? ProvidedTypeDefinition as m  -> m.GetCustomAttributesDataImpl()
+            | :? ProvidedMethod as m  -> m.GetCustomAttributesDataImpl()
+            | :? ProvidedProperty as m  -> m.GetCustomAttributesDataImpl()
+            | :? ProvidedConstructor as m -> m.GetCustomAttributesDataImpl()
+            | :? ProvidedEvent as m -> m.GetCustomAttributesDataImpl()
+            | :?  ProvidedLiteralField as m -> m.GetCustomAttributesDataImpl()
+            | :?  ProvidedField as m -> m.GetCustomAttributesDataImpl()
+            | _ -> [| |] :> IList<_>
+
+        member __.GetParameterCustomAttributesData(methodBase) = 
+            match methodBase with
+            | :? ProvidedParameter as m  -> m.GetCustomAttributesDataImpl()
+            | _ -> [| |] :> IList<_>
+
+
+#endif
         override this.GetStaticParameters(ty) =
             match ty with
             | :? ProvidedTypeDefinition as t ->
@@ -1214,10 +2276,29 @@ type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<Provided
             | :? ProvidedTypeDefinition as t -> (t.MakeParametricType(typePathAfterArguments,objs) :> Type)
             | _ -> failwith (sprintf "ApplyStaticArguments: static params for type %s are unexpected" ty.FullName)
 
-        override x.GetGeneratedAssemblyContents(assembly) = 
+#if FX_NO_LOCAL_FILESYSTEM
+        override x.GetGeneratedAssemblyContents(_assembly) = 
+            // TODO: this is very fake, we rely on the fact it is never needed
+            match System.Windows.Application.GetResourceStream(System.Uri("FSharp.Core.dll",System.UriKind.Relative)) with 
+            | null -> failwith "FSharp.Core.dll not found as Manifest Resource, we're just trying to read some random .NET assembly, ok?"
+            | resStream ->  
+                use stream = resStream.Stream
+                let len = stream.Length
+                let buf = Array.zeroCreate<byte> (int len)
+                let rec loop where rem = 
+                    let n = stream.Read(buf, 0, int rem)
+                    if n < rem then loop (where  + n) (rem - n)
+                loop 0 (int len) 
+                buf
+
+            //failwith "no file system"
+#else
+        override x.GetGeneratedAssemblyContents(assembly:Assembly) = 
+            //printfn "looking up assembly '%s'" assembly.FullName
             match GlobalProvidedAssemblyElementsTable.theTable.TryGetValue assembly with 
-            | true,bytes -> bytes
+            | true,bytes -> bytes.Force()
             | _ -> 
                 let bytes = System.IO.File.ReadAllBytes assembly.ManifestModule.FullyQualifiedName
-                GlobalProvidedAssemblyElementsTable.theTable.[assembly] <- bytes
+                GlobalProvidedAssemblyElementsTable.theTable.[assembly] <- Lazy.CreateFromValue bytes
                 bytes
+#endif

--- a/src/Common/ProvidedTypes-0.2.fsi
+++ b/src/Common/ProvidedTypes-0.2.fsi
@@ -9,7 +9,7 @@
 // This code is a sample for use in conjunction with the F# 3.0 Developer Preview release of September 2011.
 
 
-namespace Samples.FSharp.ProvidedTypes
+namespace ProviderImplementation.ProvidedTypes
 
 open System
 open System.Reflection
@@ -19,8 +19,8 @@ open Microsoft.FSharp.Core.CompilerServices
 /// Represents an erased provided parameter
 type ProvidedParameter =
     inherit System.Reflection.ParameterInfo
-    new : parameterName: string * parameterType: Type * ?isOut:bool * ?optionalValue:obj * ?isParamArray: bool -> ProvidedParameter
-    
+    new : parameterName: string * parameterType: Type * ?isOut:bool * ?optionalValue:obj -> ProvidedParameter
+    member IsParamArray : bool with get,set
 
 /// Represents an erased provided constructor.
 type ProvidedConstructor =    
@@ -28,6 +28,9 @@ type ProvidedConstructor =
 
     /// Create a new provided constructor. It is not initially associated with any specific provided type definition.
     new : parameters: ProvidedParameter list -> ProvidedConstructor
+
+    /// Add a 'System.Obsolete' attribute to this provided constructor
+    member AddObsoleteAttribute : message: string * ?isError: bool -> unit    
     
     /// Add XML documentation information to this provided constructor
     member AddXmlDoc          : xmlDoc: string -> unit   
@@ -41,18 +44,30 @@ type ProvidedConstructor =
     /// Set the quotation used to compute the implementation of invocations of this constructor.
     member InvokeCode         : (Quotations.Expr list -> Quotations.Expr) with set
 
-    /// Set the function used to compute the implementation of invocations of this constructor.
-    member InvokeCodeInternal         : (Quotations.Expr[] -> Quotations.Expr) with get,set
+    /// FSharp.Data addition: this method is used by Debug.fs
+    member internal GetInvokeCodeInternal : bool -> (Quotations.Expr [] -> Quotations.Expr)
+
+    /// Set the target and arguments of the base constructor call. Only used for generated types.
+    member BaseConstructorCall : (Quotations.Expr list -> ConstructorInfo * Quotations.Expr list) with set
+
+    /// Set a flag indicating that the constructor acts like an F# implicit constructor, so the
+    /// parameters of the constructor become fields and can be accessed using Expr.GlobalVar with the
+    /// same name.
+    member IsImplicitCtor : bool with set
 
     /// Add definition location information to the provided constructor.
     member AddDefinitionLocation : line:int * column:int * filePath:string -> unit
     
+    member IsTypeInitializer : bool with get,set
 
 type ProvidedMethod = 
     inherit System.Reflection.MethodInfo
 
     /// Create a new provided method. It is not initially associated with any specific provided type definition.
     new : methodName:string * parameters: ProvidedParameter list * returnType: Type -> ProvidedMethod
+
+    /// Add XML documentation information to this provided method
+    member AddObsoleteAttribute : message: string * ?isError: bool -> unit    
 
     /// Add XML documentation information to this provided constructor
     member AddXmlDoc            : xmlDoc: string -> unit    
@@ -75,9 +90,8 @@ type ProvidedMethod =
     /// Set the quotation used to compute the implementation of invocations of this method.
     member InvokeCode         : (Quotations.Expr list -> Quotations.Expr) with set
 
-    /// Set the function used to compute the implementation of invocations of this method.
-    member InvokeCodeInternal         : (Quotations.Expr[] -> Quotations.Expr) with get,set
-
+    /// FSharp.Data addition: this method is used by Debug.fs
+    member internal GetInvokeCodeInternal : bool -> (Quotations.Expr [] -> Quotations.Expr)
 
     /// Add definition location information to the provided type definition.
     member AddDefinitionLocation : line:int * column:int * filePath:string -> unit
@@ -90,6 +104,39 @@ type ProvidedProperty =
 
     /// Create a new provided type. It is not initially associated with any specific provided type definition.
     new  : propertyName: string * propertyType: Type * ?parameters:ProvidedParameter list -> ProvidedProperty
+
+    /// Add a 'System.Obsolete' attribute to this provided property
+    member AddObsoleteAttribute : message: string * ?isError: bool -> unit    
+
+    /// Add XML documentation information to this provided constructor
+    member AddXmlDoc            : xmlDoc: string -> unit    
+
+    /// Add XML documentation information to this provided constructor, where the computation of the documentation is delayed until necessary
+    member AddXmlDocDelayed   : xmlDocFunction: (unit -> string) -> unit   
+    
+    /// Add XML documentation information to this provided constructor, where the computation of the documentation is delayed until necessary
+    /// The documentation is re-computed  every time it is required.
+    member AddXmlDocComputed   : xmlDocFunction: (unit -> string) -> unit   
+    
+    /// Get or set a flag indicating if the property is static.
+    /// FSharp.Data addition: the getter is used by Debug.fs
+    member IsStatic             : bool with get,set
+
+    /// Set the quotation used to compute the implementation of gets of this property.
+    member GetterCode           : (Quotations.Expr list -> Quotations.Expr) with set
+
+    /// Set the function used to compute the implementation of sets of this property.
+    member SetterCode           : (Quotations.Expr list -> Quotations.Expr) with set
+
+    /// Add definition location information to the provided type definition.
+    member AddDefinitionLocation : line:int * column:int * filePath:string -> unit
+
+/// Represents an erased provided property.
+type ProvidedEvent =
+    inherit System.Reflection.EventInfo
+
+    /// Create a new provided type. It is not initially associated with any specific provided type definition.
+    new  : propertyName: string * eventHandlerType: Type -> ProvidedEvent
 
     /// Add XML documentation information to this provided constructor
     member AddXmlDoc            : xmlDoc: string -> unit    
@@ -105,42 +152,95 @@ type ProvidedProperty =
     member IsStatic             : bool with set
 
     /// Set the quotation used to compute the implementation of gets of this property.
-    member GetterCode           : (Quotations.Expr list -> Quotations.Expr) with set
-
-    /// Set the function used to compute the implementation of gets of this property.
-    member GetterCodeInternal : (Quotations.Expr[] -> Quotations.Expr) with get,set
+    member AdderCode           : (Quotations.Expr list -> Quotations.Expr) with set
 
     /// Set the function used to compute the implementation of sets of this property.
-    member SetterCode           : (Quotations.Expr list -> Quotations.Expr) with set
-
-    /// Set the function used to compute the implementation of sets of this property.
-    member SetterCodeInternal : (Quotations.Expr[] -> Quotations.Expr) with get,set
+    member RemoverCode           : (Quotations.Expr list -> Quotations.Expr) with set
 
     /// Add definition location information to the provided type definition.
     member AddDefinitionLocation : line:int * column:int * filePath:string -> unit
 
-/// Represents an erased provided property.
+/// Represents an erased provided field.
 type ProvidedLiteralField =
     inherit System.Reflection.FieldInfo
 
-    /// Create a new provided type. It is not initially associated with any specific provided type definition.
+    /// Create a new provided field. It is not initially associated with any specific provided type definition.
     new  : fieldName: string * fieldType: Type * literalValue: obj -> ProvidedLiteralField
 
-    /// Add XML documentation information to this provided constructor
+    /// Add a 'System.Obsolete' attribute to this provided field
+    member AddObsoleteAttribute : message: string * ?isError: bool -> unit    
+
+    /// Add XML documentation information to this provided field
     member AddXmlDoc            : xmlDoc: string -> unit    
 
-    /// Add XML documentation information to this provided constructor, where the computation of the documentation is delayed until necessary
+    /// Add XML documentation information to this provided field, where the computation of the documentation is delayed until necessary
     member AddXmlDocDelayed   : xmlDocFunction: (unit -> string) -> unit   
     
-    /// Add XML documentation information to this provided constructor, where the computation of the documentation is delayed until necessary
+    /// Add XML documentation information to this provided field, where the computation of the documentation is delayed until necessary
     /// The documentation is re-computed  every time it is required.
     member AddXmlDocComputed   : xmlDocFunction: (unit -> string) -> unit   
 
-    /// Add definition location information to the provided type definition.
+    /// Add definition location information to the provided field.
     member AddDefinitionLocation : line:int * column:int * filePath:string -> unit
 
+/// Represents an erased provided field.
+type ProvidedField =
+    inherit System.Reflection.FieldInfo
 
-/// Represents an erased provided property.
+    /// Create a new provided field. It is not initially associated with any specific provided type definition.
+    new  : fieldName: string * fieldType: Type -> ProvidedField
+
+    /// Add a 'System.Obsolete' attribute to this provided field
+    member AddObsoleteAttribute : message: string * ?isError: bool -> unit    
+
+    /// Add XML documentation information to this provided field
+    member AddXmlDoc            : xmlDoc: string -> unit    
+
+    /// Add XML documentation information to this provided field, where the computation of the documentation is delayed until necessary
+    member AddXmlDocDelayed   : xmlDocFunction: (unit -> string) -> unit   
+    
+    /// Add XML documentation information to this provided field, where the computation of the documentation is delayed until necessary
+    /// The documentation is re-computed  every time it is required.
+    member AddXmlDocComputed   : xmlDocFunction: (unit -> string) -> unit   
+
+    /// Add definition location information to the provided field definition.
+    member AddDefinitionLocation : line:int * column:int * filePath:string -> unit
+
+    member SetFieldAttributes : attributes : FieldAttributes -> unit
+
+/// FSharp.Data addition: SymbolKind is used by AssemblyReplacer.fs
+/// Represents the type constructor in a provided symbol type.
+type SymbolKind = 
+    | SDArray 
+    | Array of int 
+    | Pointer 
+    | ByRef 
+    | Generic of System.Type 
+    | FSharpTypeAbbreviation of (System.Reflection.Assembly * string * string[])
+
+/// FSharp.Data addition: ProvidedSymbolType is used by AssemblyReplacer.fs
+/// Represents an array or other symbolic type involving a provided type as the argument.
+/// See the type provider spec for the methods that must be implemented.
+/// Note that the type provider specification does not require us to implement pointer-equality for provided types.
+[<Class>]
+type ProvidedSymbolType =
+    inherit System.Type
+
+    /// Returns the kind of this symbolic type
+    member Kind : SymbolKind
+    /// Return the provided types used as arguments of this symbolic type
+    member Args : list<System.Type>
+
+
+/// Provides symbolic provided types
+[<Class>]
+type ProvidedTypeBuilder =
+    /// Like typ.MakeGenericType, but will also work with unit-annotated types
+    static member MakeGenericType: genericTypeDefinition: System.Type * genericArguments: System.Type list -> System.Type
+    /// Like methodInfo.MakeGenericMethod, but will also work with unit-annotated types and provided types
+    static member MakeGenericMethod: genericMethodDefinition: System.Reflection.MethodInfo * genericArguments: System.Type list -> MethodInfo
+
+/// Helps create erased provided unit-of-measure annotations.
 [<Class>]
 type ProvidedMeasureBuilder =
     
@@ -168,7 +268,7 @@ type ProvidedMeasureBuilder =
 
 
 /// Represents a provided static parameter.
-type internal ProvidedStaticParameter =
+type ProvidedStaticParameter =
     inherit System.Reflection.ParameterInfo
     new : parameterName: string * parameterType:Type * ?parameterDefaultValue:obj -> ProvidedStaticParameter
 
@@ -191,14 +291,23 @@ type ProvidedTypeDefinition =
     /// Add the given type as an implemented interface.
     member AddInterfaceImplementation : interfaceType: Type -> unit    
 
+    /// Add the given function as a set of on-demand computed interfaces.
+    member AddInterfaceImplementationsDelayed : interfacesFunction:(unit -> Type  list)-> unit    
+
     /// Specifies that the given method body implements the given method declaration.
     member DefineMethodOverride : methodInfoBody: ProvidedMethod * methodInfoDeclaration: MethodInfo -> unit
+
+    /// Add a 'System.Obsolete' attribute to this provided type definition
+    member AddObsoleteAttribute : message: string * ?isError: bool -> unit    
 
     /// Add XML documentation information to this provided constructor
     member AddXmlDoc             : xmlDoc: string -> unit    
 
     /// Set the base type
     member SetBaseType             : Type -> unit    
+
+    /// Set the base type to a lazily evaluated value
+    member SetBaseTypeDelayed      : Lazy<Type option> -> unit    
 
     /// Add XML documentation information to this provided constructor, where the computation of the documentation is delayed until necessary.
     /// The documentation is only computed once.
@@ -210,6 +319,9 @@ type ProvidedTypeDefinition =
     
     /// Set the attributes on the provided type. This fully replaces the default TypeAttributes.
     member SetAttributes        : System.Reflection.TypeAttributes -> unit
+    
+    /// Reset the enclosing type (for generated nested types)
+    member ResetEnclosingType: enclosingType:System.Type -> unit
     
     /// Add a method, property, nested type or other member to a ProvidedTypeDefinition
     member AddMember         : memberInfo:MemberInfo      -> unit  
@@ -234,17 +346,6 @@ type ProvidedTypeDefinition =
     /// Suppress System.Object entries in intellisense menus in instances of this provided type 
     member HideObjectMethods  : bool with set
 
-    /// Emit the given provided type definition and its nested type definitions into an assembly 
-    /// and adjust the 'Assembly' property of all provided type definitions to return that
-    /// assembly.
-    ///
-    /// The assembly is only emitted when the Assembly property on the root type is accessed for the first time.
-    /// The host F# compiler does this when processing a generative type declaration for the type.
-    member ConvertToGenerated : assemblyFileName: string  * ?reportAssembly: (Assembly * byte[] -> unit) -> unit
-
-    /// Register that a given file is a provided generated assembly
-    static member RegisterGenerated : fileName:string -> Assembly
-
     /// Get or set a flag indicating if the ProvidedTypeDefinition is erased
     member IsErased : bool  with get,set
 
@@ -252,20 +353,69 @@ type ProvidedTypeDefinition =
     [<Experimental("SuppressRelocation is a workaround and likely to be removed")>]
     member SuppressRelocation : bool  with get,set
 
+    /// FSharp.Data addition: this method is used by Debug.fs
+    member MakeParametricType : name:string * args:obj[] -> ProvidedTypeDefinition
+
+    /// FSharp.Data addition: this method is used by Debug.fs and QuotationBuilder.fs
+    /// Emulate the F# type provider type erasure mechanism to get the 
+    /// actual (erased) type. We erase ProvidedTypes to their base type
+    /// and we erase array of provided type to array of base type. In the
+    /// case of generics all the generic type arguments are also recursively
+    /// replaced with the erased-to types
+    static member EraseType : t:Type -> Type
+
+/// A provided generated assembly
+type ProvidedAssembly =
+    new : assemblyFileName:string -> ProvidedAssembly
+    /// <summary>
+    /// Emit the given provided type definitions as part of the assembly 
+    /// and adjust the 'Assembly' property of all provided type definitions to return that
+    /// assembly.
+    ///
+    /// The assembly is only emitted when the Assembly property on the root type is accessed for the first time.
+    /// The host F# compiler does this when processing a generative type declaration for the type.
+    /// </summary>
+    /// <param name="enclosingTypeNames">An optional path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
+    member AddTypes : types : ProvidedTypeDefinition list -> unit
+    member AddNestedTypes : types : ProvidedTypeDefinition list * enclosingGeneratedTypeNames: string list -> unit
+
+#if FX_NO_LOCAL_FILESYSTEM
+#else
+    /// Register that a given file is a provided generated assembly
+    static member RegisterGenerated : fileName:string -> Assembly
+#endif
+
+
 /// A base type providing default implementations of type provider functionality when all provided 
 /// types are of type ProvidedTypeDefinition.
 type TypeProviderForNamespaces =
 
     /// Initializes a type provider to provide the types in the given namespace.
-    new : namespaceName:string * types: ProvidedTypeDefinition list -> TypeProviderForNamespaces
+    internal new : namespaceName:string * types: ProvidedTypeDefinition list -> TypeProviderForNamespaces
 
     /// Initializes a type provider 
-    new : unit -> TypeProviderForNamespaces
+    internal new : unit -> TypeProviderForNamespaces
 
     /// Add a namespace of provided types.
-    member AddNamespace : namespaceName:string * types: ProvidedTypeDefinition list -> unit
+    member internal AddNamespace : namespaceName:string * types: ProvidedTypeDefinition list -> unit
+
+    /// FSharp.Data addition: this method is used by Debug.fs
+    /// Get all namespace with their provided types.
+    member Namespaces : (string * ProvidedTypeDefinition list) seq with get
 
     /// Invalidate the information provided by the provider
     member Invalidate : unit -> unit
+
+#if FX_NO_LOCAL_FILESYSTEM
+#else
+    /// AssemblyResolve handler. Default implementation searches <assemblyname>.dll file in registered folders 
+    abstract ResolveAssembly : System.ResolveEventArgs -> Assembly
+    default ResolveAssembly : System.ResolveEventArgs -> Assembly
+
+    /// Registers custom probing path that can be used for probing assemblies
+    member RegisterProbingFolder : folder : string -> unit
+    /// Registers location of RuntimeAssembly (from TypeProviderConfig) as probing folder
+    member RegisterRuntimeAssemblyLocationAsProbingFolder : cfg : Core.CompilerServices.TypeProviderConfig -> unit
+#endif
 
     interface ITypeProvider

--- a/src/RDataProvider/Example.fsx
+++ b/src/RDataProvider/Example.fsx
@@ -1,0 +1,19 @@
+﻿#r @"..\..\bin\RDotNet.dll"
+#r @"..\..\bin\RProvider.dll"
+#r @"..\..\bin\RProvider.Runtime.dll"
+#r @"..\..\bin\RDataProvider.dll"
+
+open RProvider
+open RProvider.``base``
+
+type Foo = RData<"C:\\Temp\\Test.rdata">
+let f = new Foo()
+f.cars
+f.bar
+
+
+
+// Define your library scripting code here
+
+System.Environment.GetEnvironmentVariables()
+

--- a/src/RDataProvider/RData.fs
+++ b/src/RDataProvider/RData.fs
@@ -1,0 +1,85 @@
+﻿namespace ProviderImplementation
+
+open Microsoft.FSharp.Core.CompilerServices
+open ProviderImplementation.ProvidedTypes
+open Microsoft.FSharp.Quotations
+open RProvider
+
+//module Globals = 
+//  let mutable initialized = false
+
+type REnv(fileName:string) =
+  let env = RInterop.callFunc "base" "new.env" [] [||] // R.new_env() 
+  do RInterop.callFunc "base" "load" (namedParams [ "file", box fileName; "envir", box env ]) [| |] |> ignore
+  member x.Environment = env
+  member x.Get(name:string) = 
+    RInterop.callFunc "base" "get" (namedParams ["x", box name; "envir", box env]) [||]
+  
+[<TypeProvider>]
+type public RDataProvider(cfg:TypeProviderConfig) as this =
+  inherit TypeProviderForNamespaces()
+
+  do 
+      System.AppDomain.CurrentDomain.add_AssemblyResolve(fun _ e ->
+        let asms = System.AppDomain.CurrentDomain.GetAssemblies()
+        let loaded = asms |> Seq.tryFind (fun asm -> asm.FullName = e.Name)
+        defaultArg loaded null )
+(*
+        // 
+
+        let name = 
+          let comma = e.Name.IndexOf(',')
+          (if comma > 0 then e.Name.Substring(0, comma) else e.Name) + ".dll"
+
+        let asmOpt = 
+          Seq.concat
+            [ cfg.ReferencedAssemblies 
+              System.IO.Directory.GetFiles(System.IO.Path.GetDirectoryName(typeof<RDataProvider>.Assembly.Location), "*.dll") ]
+          |> Seq.tryFind (fun asm -> asm.EndsWith(name, System.StringComparison.InvariantCultureIgnoreCase))
+          |> Option.map System.Reflection.Assembly.LoadFile
+
+        defaultArg asmOpt null )
+*)
+  // Boilerplate that generates root type in current assembly
+  let asm = System.Reflection.Assembly.GetExecutingAssembly()
+  let ns = "RProvider"
+  let iniType = ProvidedTypeDefinition(asm, ns, "RData", Some(typeof<obj>))
+  
+  // Add static parameter that specifies the (compile-time) ini file
+  let parameter = ProvidedStaticParameter("FileName", typeof<string>)
+  do iniType.DefineStaticParameters([parameter], fun typeName args ->
+
+    let fileName = args.[0] :?> string
+
+    let env = REnv(fileName)
+
+    // -------------------------------------------------------------
+
+    let resTy = ProvidedTypeDefinition(asm, ns, typeName, Some typeof<REnv>)
+
+    let ctor = ProvidedConstructor([])
+    ctor.InvokeCode <- fun _ -> <@@ REnv(fileName) @@>
+    resTy.AddMember(ctor)
+
+    let ctor = ProvidedConstructor([ProvidedParameter("fileName", typeof<string>)])
+    ctor.InvokeCode <- fun [fn] -> <@@ REnv(%%fn) @@>
+    resTy.AddMember(ctor)
+
+    let ls = RInterop.callFunc "base" "ls" (namedParams ["envir", box env.Environment]) [||]
+    for f in ls.GetValue<string[]>()  do
+      let v = env.Get(f)
+      try 
+        let typ = v.Value.GetType()
+        ProvidedProperty(f, typ, GetterCode = fun [self] -> Expr.Coerce(<@@ ((%%self):REnv).Get(f).Value @@>, typ))
+        |> resTy.AddMember
+      with _ -> 
+        ProvidedProperty(f, typeof<RDotNet.SymbolicExpression>, GetterCode = fun [self] ->  <@@ ((%%self):REnv).Get(f) @@>)
+        |> resTy.AddMember
+
+    resTy) 
+
+  // Register the main (parameterized) type with F# compiler
+  do this.AddNamespace(ns, [ iniType ])
+
+[<assembly:TypeProviderAssembly>]
+do()

--- a/src/RDataProvider/RDataProvider.fsproj
+++ b/src/RDataProvider/RDataProvider.fsproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>56ffd489-ca6d-4bb4-a5c2-9c74d9f4d087</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>RDataProvider</RootNamespace>
+    <AssemblyName>RDataProvider</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <Name>RDataProvider</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>../../bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>
+    </DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <DocumentationFile>bin\Release\RDataProvider.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RDotNet">
+      <HintPath>D:\Local\Public\FSharp.RProvider\packages\R.NET.1.5.5\lib\net40\RDotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\AssemblyInfo.fs">
+      <Link>AssemblyInfo.fs</Link>
+    </Compile>
+    <Compile Include="..\Common\ProvidedTypes-0.2.fsi">
+      <Link>ProvidedTypes-0.2.fsi</Link>
+    </Compile>
+    <Compile Include="..\Common\ProvidedTypes-0.2.fs">
+      <Link>ProvidedTypes-0.2.fs</Link>
+    </Compile>
+    <Compile Include="RData.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RProvider\RProvider.Runtime.fsproj">
+      <Name>RProvider.Runtime</Name>
+      <Project>{7ff9cfa3-2516-4970-9dd8-54c7d4ca24aa}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/RProvider/RProvider.fsproj
+++ b/src/RProvider/RProvider.fsproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>../../bin</OutputPath>
+    <OutputPath>../../bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <OtherFlags>


### PR DESCRIPTION
I wrote this prototype during a recent "type provider coding dojo" at the London F# user group. It needs a bit more work (some cleanup and testing), but it should not be too much work to finish it. I recently came across a [StackOverflow question](http://stackoverflow.com/questions/22991041/reading-writing-rdata-from-c-sharp-or-f-deedle-package) asking about this, so it looks like this would be genuinely useful.

This lets you write:

```
open RProvider
open RProvider.``base``

 type Foo = RData<"C:\\Temp\\Test.rdata">
 let f = new Foo()
 f.cars
 f.bar
```

In the current version, the types of the properties (`f.cars` and `f.bar`) are F# types that would be returned by the `Value` property (using whatever plugins are loaded currently). This means that in this example, I get `cars` of type `Frame<string, string>` (using Deedle frames) and `bar` is `float[]`. If there is no default converter, you get just `SymbolicExpression`.

An alternative would be to return something like a `TypedExpression<'T>` which has `Value : 'T` and is `SymbolicExpression` (so that you can access the value as symbolic expression if you want to keep it in the R environment). Now that I think of it, that would probably be a better option...

Any feedback & thoughts would be welcome!

/cc @adamklein @hmansell @dcharbon 
