### PR TITLE
Adopt latest R.Net for concurrency fixes

### DIFF
--- a/nuget/RProvider.nuspec
+++ b/nuget/RProvider.nuspec
@@ -15,8 +15,8 @@
     <tags>@tags@</tags>
     <language>en-US</language>
     <dependencies>
-      <dependency id="R.NET" version="1.5.5" />
-      <dependency id="RDotNet.FSharp" version="0.1.2.1" />
+      <dependency id="R.NET" version="1.5.12" />
+      <dependency id="RDotNet.FSharp" version="0.1.5" />
     </dependencies>    
   </metadata>
   <files>

--- a/src/RProvider/DesignTime.fs
+++ b/src/RProvider/DesignTime.fs
@@ -29,12 +29,6 @@ module DesignTime =
           AppDomain.CurrentDomain.add_AssemblyResolve(fun source args ->
             resolveReferencedAssembly args.Name)
       
-          // Set the R 'R_CStackLimit' variable to -1 when initializing the R engine
-          // (the engine is initialized lazily, so the initialization always happens
-          // after the static constructor is called - by doing this in the static constructor
-          // we make sure that this is *not* set in the normal execution)
-          RInit.DisableStackChecking <- true
-
         // Generate all the types and log potential errors
         let buildTypes () =
             try 

--- a/src/RProvider/RInit.fs
+++ b/src/RProvider/RInit.fs
@@ -6,24 +6,6 @@ open Microsoft.Win32
 open RDotNet
 open RProvider
 
-/// When set to 'true' before the R engine is initialized, the initialization
-/// will set the 'R_CStackLimit' variable to -1 (which disables stack checking
-/// in the R engine and makes it possible to call R engine from multiple threads
-///
-/// This should not generally be done, but it is hard to avoid in a type provider
-/// called by the F# compiler and engine called by user code.
-///
-/// When this is *not* done, the R provider will occasionally report 
-/// "Error: C stack usage is too close to the limit" when it is called from 
-/// another thread (not concurrently, just from another thread than previously).
-///
-/// For more information, see somewhat vague comment "8.1.5 Threading issues" 
-/// in: www.cran.r-project.org/doc/manuals/R-exts.pdf
-///
-/// NOTE: For this to work correctly, the R engine must be initialized lazily
-/// *after* this variable is set in the static constructor of the RProvider
-let mutable DisableStackChecking = false
-
 /// Represents R value used in initialization or information about failure
 type RInitResult<'T> =
   | RInitResult of 'T
@@ -85,9 +67,7 @@ let internal characterDevice = new CharacterDeviceInterceptor()
 /// to include the R location, or fails and returns RInitError
 let initResult = Lazy<_>(fun () -> setupPathVariable())
 
-/// Lazily initialized R engine. When 'DisableStackChecking' has been set prior
-/// to the initialization (in the static constructor of RProvider), then 
-/// set the 'R_CStackLimit' variable to -1.
+/// Lazily initialized R engine.
 let internal engine = Lazy<_>(fun () ->
     try
         Logging.logf "engine: Creating instance" 
@@ -95,12 +75,6 @@ let internal engine = Lazy<_>(fun () ->
         let engine = REngine.GetInstance()
         Logging.logf "engine: Intializing instance"
         engine.Initialize(null, characterDevice)
-            
-        if DisableStackChecking then
-            // This needs to be called *after* the initialization of REngine
-            let varAddress = engine.DangerousGetHandle("R_CStackLimit")
-            System.Runtime.InteropServices.Marshal.WriteInt32(varAddress, -1)
-    
         System.AppDomain.CurrentDomain.DomainUnload.Add(fun _ -> engine.Dispose()) 
         Logging.logf "engine: Created & initialized instance"
         engine

--- a/src/RProvider/RInit.fs
+++ b/src/RProvider/RInit.fs
@@ -71,8 +71,7 @@ let private setupPathVariable () =
               RInitError (sprintf "No R engine at %s" binPath)
           else
               // Set the path
-              let pathSepChar = if isLinux then ":" else ";"
-              Environment.SetEnvironmentVariable("PATH", Environment.GetEnvironmentVariable("PATH") + pathSepChar + binPath)
+              REngine.SetEnvironmentVariables(binPath, location)
               Logging.logf "setupPathVariable completed"
               RInitResult ()
     with e ->
@@ -93,7 +92,7 @@ let internal engine = Lazy<_>(fun () ->
     try
         Logging.logf "engine: Creating instance" 
         initResult.Force() |> ignore
-        let engine = REngine.CreateInstance(System.AppDomain.CurrentDomain.Id.ToString())
+        let engine = REngine.GetInstance()
         Logging.logf "engine: Intializing instance"
         engine.Initialize(null, characterDevice)
             

--- a/src/RProvider/RInteropServer.fs
+++ b/src/RProvider/RInteropServer.fs
@@ -12,27 +12,41 @@ type RInteropServer() =
     
     let initResultValue = RInit.initResult.Force()
 
+    let exceptionSafe f =
+        try
+            f()
+        with
+        | ex when ex.GetType().IsSerializable -> raise ex
+        | ex ->
+            failwith ex.Message
+
     member x.RInitValue =
         match initResultValue with
         | RInit.RInitError error -> Some error
         | _ -> None
 
     member x.GetPackages() =
-        getPackages()
+        exceptionSafe <| fun () ->
+            getPackages()
 
     member x.LoadPackage(package) =
-        loadPackage package
+        exceptionSafe <| fun () ->
+            loadPackage package
         
     member x.GetBindings(package) =
-        getBindings package
+        exceptionSafe <| fun () ->
+            getBindings package
         
     member x.GetFunctionDescriptions(package:string) =
-        getFunctionDescriptions package
+        exceptionSafe <| fun () ->
+            getFunctionDescriptions package
         
     member x.GetPackageDescription(package) =
-        getPackageDescription package
+        exceptionSafe <| fun () ->
+            getPackageDescription package
         
     member x.MakeSafeName(name) =
-        makeSafeName name
+        exceptionSafe <| fun () ->
+            makeSafeName name
 
 

--- a/src/RProvider/RInteropServer.fs
+++ b/src/RProvider/RInteropServer.fs
@@ -10,45 +10,29 @@ open System
 type RInteropServer() =
     inherit MarshalByRefObject()
     
-    // Set the R 'R_CStackLimit' variable to -1 when initializing the R engine
-    // (the engine is initialized lazily, so the initialization always happens
-    // after the static constructor is called - by doing this in the static constructor
-    // we make sure that this is *not* set in the normal execution)
-    static do RInit.DisableStackChecking <- true
-    
     let initResultValue = RInit.initResult.Force()
-    let serverLock = "serverLock"
-    let withLock f =
-        lock serverLock f
 
     member x.RInitValue =
-        withLock <| fun () ->
-            match initResultValue with
-            | RInit.RInitError error -> Some error
-            | _ -> None
+        match initResultValue with
+        | RInit.RInitError error -> Some error
+        | _ -> None
 
     member x.GetPackages() =
-         withLock <| fun () ->
-            getPackages()
+        getPackages()
 
     member x.LoadPackage(package) =
-        withLock <| fun () ->
-            loadPackage package
+        loadPackage package
         
     member x.GetBindings(package) =
-        withLock <| fun () ->
-            getBindings package
+        getBindings package
         
     member x.GetFunctionDescriptions(package:string) =
-        withLock <| fun () ->
-            getFunctionDescriptions package
+        getFunctionDescriptions package
         
     member x.GetPackageDescription(package) =
-        withLock <| fun () ->
-            getPackageDescription package
+        getPackageDescription package
         
     member x.MakeSafeName(name) =
-        withLock <| fun () ->
-            makeSafeName name
+        makeSafeName name
 
 

--- a/src/RProvider/RProvider.DesignTime.fsproj
+++ b/src/RProvider/RProvider.DesignTime.fsproj
@@ -63,8 +63,9 @@
   <ItemGroup>
     <Reference Include="FSharp.Core" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.dll</HintPath>
     </Reference>
+    <Reference Include="RDotNet.NativeLibrary" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />

--- a/src/RProvider/RProvider.Runtime.fsproj
+++ b/src/RProvider/RProvider.Runtime.fsproj
@@ -61,13 +61,13 @@
     <Reference Include="FSharp.Core" />
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.dll</HintPath>
     </Reference>
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\RDotNet.FSharp.0.1.2.1\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\RDotNet.FSharp.0.1.5\lib\net40\RDotNet.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/RProvider/RProvider.Server.fsproj
+++ b/src/RProvider/RProvider.Server.fsproj
@@ -68,15 +68,15 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\RDotNet.FSharp.0.1.2.1\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\RDotNet.FSharp.0.1.5\lib\net40\RDotNet.FSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/RProvider/RProvider.fsproj
+++ b/src/RProvider/RProvider.fsproj
@@ -59,13 +59,13 @@
     <Reference Include="FSharp.Core" />
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.dll</HintPath>
     </Reference>
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\RDotNet.FSharp.0.1.2.1\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\RDotNet.FSharp.0.1.5\lib\net40\RDotNet.FSharp.dll</HintPath>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/RProvider/packages.config
+++ b/src/RProvider/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="R.NET" version="1.5.5" targetFramework="net45" />
-  <package id="RDotNet.FSharp" version="0.1.2.1" targetFramework="net45" />
+  <package id="R.NET" version="1.5.12" targetFramework="net45" />
+  <package id="RDotNet.FSharp" version="0.1.5" targetFramework="net45" />
 </packages>

--- a/src/RWrapperGenerator/RWrapperGenerator.fsproj
+++ b/src/RWrapperGenerator/RWrapperGenerator.fsproj
@@ -13,6 +13,7 @@
     <Name>RWrapperGenerator</Name>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,20 +40,20 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\RDotNet.FSharp.0.1.2.1\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\RDotNet.FSharp.0.1.5\lib\net40\RDotNet.FSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -93,7 +94,19 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/RWrapperGenerator/RWrapperGenerator.fsproj
+++ b/src/RWrapperGenerator/RWrapperGenerator.fsproj
@@ -94,18 +94,12 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '11.0'">
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <PropertyGroup>
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) != 'Windows_NT'">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/RWrapperGenerator/packages.config
+++ b/src/RWrapperGenerator/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="R.NET" version="1.5.5" targetFramework="net45" />
-  <package id="RDotNet.FSharp" version="0.1.2.1" targetFramework="net45" />
+  <package id="R.NET" version="1.5.12" targetFramework="net45" />
+  <package id="RDotNet.FSharp" version="0.1.5" targetFramework="net45" />
 </packages>

--- a/tests/Test.RProvider/Test.RProvider.fsproj
+++ b/tests/Test.RProvider/Test.RProvider.fsproj
@@ -80,9 +80,6 @@
     <Reference Include="RProvider">
       <HintPath>..\..\bin\RProvider.dll</HintPath>
     </Reference>
-    <Reference Include="RProvider.DesignTime">
-      <HintPath>..\..\bin\RProvider.DesignTime.dll</HintPath>
-    </Reference>
     <Reference Include="RProvider.Runtime">
       <HintPath>..\..\bin\RProvider.Runtime.dll</HintPath>
     </Reference>

--- a/tests/Test.RProvider/Test.RProvider.fsproj
+++ b/tests/Test.RProvider/Test.RProvider.fsproj
@@ -70,15 +70,18 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.1.5.5\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.1.5.12\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RProvider">
       <HintPath>..\..\bin\RProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="RProvider.DesignTime">
+      <HintPath>..\..\bin\RProvider.DesignTime.dll</HintPath>
     </Reference>
     <Reference Include="RProvider.Runtime">
       <HintPath>..\..\bin\RProvider.Runtime.dll</HintPath>

--- a/tests/Test.RProvider/packages.config
+++ b/tests/Test.RProvider/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="FsCheck" version="0.9.2.0" targetFramework="net45" />
   <package id="FsCheck.Xunit" version="0.4.0.2" targetFramework="net45" />
-  <package id="R.NET" version="1.5.5" targetFramework="net45" />
+  <package id="R.NET" version="1.5.12" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The latest R.Net 1.5.12 and RDotNet.FSharp 0.1.5 include concurrency
fixes that resolve issue #64. They might also resolve RInteropServer
disconnection issues that have been seen, though this will take some
further testing to verify.
