### PR TITLE
Fix failing unit test (conversion of strings via factors)

### DIFF
--- a/src/RProvider/Converters.fs
+++ b/src/RProvider/Converters.fs
@@ -14,12 +14,12 @@ module Factor =
         let symexpr = RInterop.call "base" "levels" rvalStr [| sexp |] [| |]
         symexpr.AsCharacter().ToArray()
 
-    let tryConvert sexp = 
-        match sexp with
-        | IntegerVector(nv) when sexp.Class = [| "factor" |] ->                
+    let tryConvert (sexp:SymbolicExpression) = 
+        match sexp, sexp.Type, sexp.Class with
+        | UntypedVector(nv), Internals.SymbolicExpressionType.IntegerVector, [| "factor" |] ->                
                 Some( let levels = getLevels sexp
-                      nv |> Seq.map (fun i -> levels.[i-1]) 
-                         |> Seq.toArray )
+                      nv.AsInteger() |> Seq.map (fun i -> levels.[i-1]) 
+                                     |> Seq.toArray )
         | _ -> None 
 
     [<Export(typeof<IConvertFromR<string[]>>)>]


### PR DESCRIPTION
I was a bit surprised by this, because the bug must have been around for a while
(we need to add continuous integration for R provider and run the tests automatically!)

The problem is that the IntegerVector in recent versions of R.NET only
succeeds when the value is _not_ a factor (there is an explicit check
`not (sexp.IsFactor())`) and so the pattern was never matched in the
convertor. This change uses R.NET only to check that the value is _some_
vector and then explicitly checks for numeric vectors (without ruling out
factors).
