### PR TITLE
Register InteropServer as a well-known singleton

### DIFF
--- a/src/RProvider/Program.fs
+++ b/src/RProvider/Program.fs
@@ -25,9 +25,9 @@ module Main =
         let event = EventWaitHandle.OpenExisting(name = channelName)
         let chan = new Ipc.IpcChannel(channelName)
         ChannelServices.RegisterChannel(chan, false)
-        let server = new RInteropServer()
-        let objRef = RemotingServices.Marshal(server, "RInteropServer")
-        RemotingConfiguration.RegisterActivatedServiceType(typeof<RInteropServer>)
+        let serviceEntry =
+            new WellKnownServiceTypeEntry(typeof<RInteropServer>, "RInteropServer", WellKnownObjectMode.Singleton)
+        RemotingConfiguration.RegisterWellKnownServiceType(serviceEntry)
         let success = event.Set()
         assert success
         let parentPid = channelName.Split('_').[1]


### PR DESCRIPTION
Issue #86 is caused by the server object being gc'd at the server. This
can be prevented by registering the server object as a
WellKnownServiceTypeEntry and specifying that the service be provided as
a singleton. This should guarantee that the lifetime of the server object will
be the lifetime of the server process.
