### PR TITLE
Upgrade to use R.NET 1.5.15

### DIFF
--- a/nuget/RProvider.nuspec
+++ b/nuget/RProvider.nuspec
@@ -15,8 +15,8 @@
     <tags>@tags@</tags>
     <language>en-US</language>
     <dependencies>
-      <dependency id="R.NET.Community" version="1.5.14" />
-      <dependency id="R.NET.Community.FSharp" version="0.1.7" />
+      <dependency id="R.NET.Community" version="1.5.15" />
+      <dependency id="R.NET.Community.FSharp" version="0.1.8" />
     </dependencies>    
   </metadata>
   <files>

--- a/src/RProvider/RProvider.DesignTime.fsproj
+++ b/src/RProvider/RProvider.DesignTime.fsproj
@@ -66,7 +66,7 @@
   <ItemGroup>
     <Reference Include="FSharp.Core" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.dll</HintPath>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary" />
     <Reference Include="System" />

--- a/src/RProvider/RProvider.Runtime.fsproj
+++ b/src/RProvider/RProvider.Runtime.fsproj
@@ -68,15 +68,15 @@
     <Reference Include="FSharp.Core" />
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.7\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.8\lib\net40\RDotNet.FSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/RProvider/RProvider.Server.fsproj
+++ b/src/RProvider/RProvider.Server.fsproj
@@ -68,15 +68,15 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.7\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.8\lib\net40\RDotNet.FSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/RProvider/RProvider.fsproj
+++ b/src/RProvider/RProvider.fsproj
@@ -59,17 +59,17 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core" />
+    <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib" />
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.7\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.8\lib\net40\RDotNet.FSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/RProvider/packages.config
+++ b/src/RProvider/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="R.NET.Community" version="1.5.14" targetFramework="net45" />
-  <package id="R.NET.Community.FSharp" version="0.1.7" targetFramework="net45" />
+  <package id="R.NET.Community" version="1.5.15" targetFramework="net45" />
+  <package id="R.NET.Community.FSharp" version="0.1.8" targetFramework="net45" />
 </packages>

--- a/src/RWrapperGenerator/RWrapperGenerator.fsproj
+++ b/src/RWrapperGenerator/RWrapperGenerator.fsproj
@@ -45,15 +45,15 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.FSharp">
-      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.7\lib\net40\RDotNet.FSharp.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.FSharp.0.1.8\lib\net40\RDotNet.FSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/RWrapperGenerator/packages.config
+++ b/src/RWrapperGenerator/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="R.NET.Community" version="1.5.14" targetFramework="net45" />
-  <package id="R.NET.Community.FSharp" version="0.1.7" targetFramework="net45" />
+  <package id="R.NET.Community" version="1.5.15" targetFramework="net45" />
+  <package id="R.NET.Community.FSharp" version="0.1.8" targetFramework="net45" />
 </packages>

--- a/tests/Test.RProvider/Test.RProvider.fsproj
+++ b/tests/Test.RProvider/Test.RProvider.fsproj
@@ -74,11 +74,11 @@
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="RDotNet">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RDotNet.NativeLibrary">
-      <HintPath>..\..\packages\R.NET.Community.1.5.14\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
+      <HintPath>..\..\packages\R.NET.Community.1.5.15\lib\net40\RDotNet.NativeLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="RProvider">

--- a/tests/Test.RProvider/packages.config
+++ b/tests/Test.RProvider/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FsCheck" version="0.9.2.0" targetFramework="net45" />
   <package id="FsCheck.Xunit" version="0.4.0.2" targetFramework="net45" />
-  <package id="R.NET.Community" version="1.5.14" targetFramework="net45" />
+  <package id="R.NET.Community" version="1.5.15" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runners" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Upgrade to use R.NET 1.5.15 to prevent possible issues noticed after a memory GC fix was added for Deedle. May or may not be an issue in different scenarios, but probably a good idea to upgrade. See https://rclr.codeplex.com/workitem/31 and https://rdotnet.codeplex.com/workitem/120. @dcharbon may want to look at the commit https://rdotnet.codeplex.com/SourceControl/changeset/1212c26806be to assess whether this fix has the potential to re-break Deedle.
