### PR TITLE
Fix assembly resolving to not interfere with loading FSharp.Core.resources, fixing #97

### DIFF
--- a/src/RProvider/Configuration.fs
+++ b/src/RProvider/Configuration.fs
@@ -49,6 +49,9 @@ let getProbingLocations() =
 /// probing directories.
 let resolveReferencedAssembly (asmName:string) = 
   
+  // Do not interfere with loading FSharp.Core resources, see #97
+  if asmName.StartsWith "FSharp.Core.resources" then null else
+
   // First, try to find the assembly in the currently loaded assemblies
   let fullName = AssemblyName(asmName)
   let loadedAsm = 


### PR DESCRIPTION
We cannot use F# core language features that require resources to be loaded while resolving them. Doing so causes an infinite loop, as seen in #97.

I suspect this only affects users with .Net language packs installed.
