### PR TITLE
Specify target framework in NuGet package

### DIFF
--- a/nuget/RProvider.Runtime.dll.config
+++ b/nuget/RProvider.Runtime.dll.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="ProbingLocations" value="../../*/lib/net40" />
+    <add key="ProbingLocations" value="../../../*/lib/net40" />
   </appSettings>
 </configuration>

--- a/nuget/RProvider.nuspec
+++ b/nuget/RProvider.nuspec
@@ -20,18 +20,18 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="..\bin\RProvider.Server.exe" target="lib" />
-    <file src="..\bin\RProvider.Server.pdb" target="lib" />
-    <file src="..\bin\RProvider.DesignTime.dll" target="lib" />
-    <file src="..\bin\RProvider.DesignTime.pdb" target="lib" />
-    <file src="..\bin\RProvider.Runtime.dll" target="lib" />
-    <file src="..\bin\RProvider.Runtime.pdb" target="lib" />
-    <file src="..\bin\RProvider.dll" target="lib" />
-    <file src="..\bin\RProvider.pdb" target="lib" />
+    <file src="..\bin\RProvider.Server.exe" target="lib\net40" />
+    <file src="..\bin\RProvider.Server.pdb" target="lib\net40" />
+    <file src="..\bin\RProvider.DesignTime.dll" target="lib\net40" />
+    <file src="..\bin\RProvider.DesignTime.pdb" target="lib\net40" />
+    <file src="..\bin\RProvider.Runtime.dll" target="lib\net40" />
+    <file src="..\bin\RProvider.Runtime.pdb" target="lib\net40" />
+    <file src="..\bin\RProvider.dll" target="lib\net40" />
+    <file src="..\bin\RProvider.pdb" target="lib\net40" />
     <file src="..\bin\RProvider.fsx" target="." />
-    <file src="..\nuget\RProvider.Runtime.dll.config" target="lib" />
-    <file src="..\nuget\FSharp.Core.dll" target="lib"/>
-    <file src="..\nuget\FSharp.Core.optdata" target="lib"/>
-    <file src="..\nuget\FSharp.Core.sigdata" target="lib"/>
+    <file src="..\nuget\RProvider.Runtime.dll.config" target="lib\net40" />
+    <file src="..\nuget\FSharp.Core.dll" target="lib\net40"/>
+    <file src="..\nuget\FSharp.Core.optdata" target="lib\net40"/>
+    <file src="..\nuget\FSharp.Core.sigdata" target="lib\net40"/>
   </files>
 </package>


### PR DESCRIPTION
This is done by convention, so assemblies are now placed in lib/net40. The
RProvider.Runtime.dll.config ProbingLocations property needed to be
updated so that the relative path is correct.
