### PR TITLE
Add FSharp.Core assembly redirect

### DIFF
--- a/src/RProvider/app.config
+++ b/src/RProvider/app.config
@@ -3,4 +3,13 @@
   <appSettings>
     <add key="ProbingLocations" value="../../*/lib/net40" />
   </appSettings>
+  <runtime>
+    <gcAllowVeryLargeObjects enabled="true" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
In some contexts the assembly redirect is necessary and a bit difficult to
debug if it it isn't there.
