### PR TITLE
Assembly reference fixes

### DIFF
--- a/src/RProvider/RProvider.Server.fsproj
+++ b/src/RProvider/RProvider.Server.fsproj
@@ -63,7 +63,7 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <Reference Include="FSharp.Core">
       <Private>False</Private>
     </Reference>
     <Reference Include="mscorlib" />

--- a/src/RProvider/app.config
+++ b/src/RProvider/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="ProbingLocations" value="../../*/lib/net40" />
+    <add key="ProbingLocations" value="../../../*/lib/net40" />
   </appSettings>
   <runtime>
     <gcAllowVeryLargeObjects enabled="true" />


### PR DESCRIPTION
Don't reference a specific version of FSharp.Core for FSharp.Server.exe
and fix probing locations path so that it expects to be in a packages
directory.
