### PR TITLE
Don't redirect FSharp.Core - it's unnecessary and undesired.

### DIFF
--- a/src/RProvider/app.config
+++ b/src/RProvider/app.config
@@ -5,11 +5,5 @@
   </appSettings>
   <runtime>
     <gcAllowVeryLargeObjects enabled="true" />
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
-      </dependentAssembly>
-    </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
The issue had been the incorrect probing path. This should have been done in #111
