### PR TITLE
Fix bug that when multiple versions of some nuget dependency exist in your packages directory

### DIFF
--- a/src/RProvider/Configuration.fs
+++ b/src/RProvider/Configuration.fs
@@ -70,9 +70,11 @@ let resolveReferencedAssembly (asmName:string) =
       getProbingLocations()
       |> Seq.tryPick (fun dir ->
           let library = Path.Combine(dir, libraryName+".dll")
-          if File.Exists(library) then 
-            let asm = Assembly.LoadFrom(library)
-            if asm.FullName = asmName then Some(asm) else None
+          if File.Exists(library) then
+            // We do a ReflectionOnlyLoad so that we can check the version
+            let refAssem = Assembly.ReflectionOnlyLoadFrom(library)
+            // If it matches, we load the actual assembly
+            if refAssem.FullName = asmName then Some(Assembly.LoadFrom(library)) else None
           else None)
              
     defaultArg asm null


### PR DESCRIPTION
Use ReflectionOnlyLoad to load the reference and check its FullName, rather than LoadFrom, as LoadFrom can only load one version of any given assembly.  Subsequent attempts to load any other version using LoadFrom just return the first version loaded.
