### PR TITLE
Always use original location instead of shadow-copied location when loading RProvider plugins

### DIFF
--- a/src/RProvider/RInterop.fs
+++ b/src/RProvider/RInterop.fs
@@ -99,10 +99,18 @@ module internal RInteropInternal =
         lazy
             // Look for plugins co-located with RProvider.dll
             let assem = typeof<IConvertToR<_>>.Assembly
+            
+            /// The location of the RProvider assembly.
+            /// If the assembly has been shadow-copied, this will be the assembly's
+            /// original location, not the shadow-copied location.
+            let assemblyLocation =
+                if System.AppDomain.CurrentDomain.ShadowCopyFiles then
+                    (new System.Uri (assem.EscapedCodeBase)).LocalPath
+                else assem.Location
            
             let dirs = getProbingLocations()
             let catalogs : seq<Primitives.ComposablePartCatalog> = 
-              seq { yield upcast new DirectoryCatalog(Path.GetDirectoryName(assem.Location),"*.Plugin.dll")
+              seq { yield upcast new DirectoryCatalog(Path.GetDirectoryName assemblyLocation,"*.Plugin.dll")
                     for d in dirs do
                       yield upcast new DirectoryCatalog(d,"*.Plugin.dll")
                     yield upcast new AssemblyCatalog(assem) }


### PR DESCRIPTION
This may or may not help fix #122 . I've used this snippet many times before (e.g., in the facio test runner) to solve a similar issue. I wasn't able to build/run the RProvider tests on my machine -- the FAKE build failed with some odd errors -- so someone will need to check whether this PR actually fixes the issue as expected.
