### PR TITLE
Fix for #122

### DIFF
--- a/src/RProvider/RInterop.fs
+++ b/src/RProvider/RInterop.fs
@@ -99,10 +99,18 @@ module internal RInteropInternal =
         lazy
             // Look for plugins co-located with RProvider.dll
             let assem = typeof<IConvertToR<_>>.Assembly
+            
+            /// The location of the RProvider assembly.
+            /// If the assembly has been shadow-copied, this will be the assembly's
+            /// original location, not the shadow-copied location.
+            let assemblyLocation =
+                if System.AppDomain.CurrentDomain.ShadowCopyFiles then
+                    (new System.Uri (assem.EscapedCodeBase)).LocalPath
+                else assem.Location
            
             let dirs = getProbingLocations()
             let catalogs : seq<Primitives.ComposablePartCatalog> = 
-              seq { yield upcast new DirectoryCatalog(Path.GetDirectoryName(assem.Location),"*.Plugin.dll")
+              seq { yield upcast new DirectoryCatalog(Path.GetDirectoryName assemblyLocation,"*.Plugin.dll")
                     for d in dirs do
                       yield upcast new DirectoryCatalog(d,"*.Plugin.dll")
                     yield upcast new AssemblyCatalog(assem) }

--- a/src/RProvider/RInteropClient.fs
+++ b/src/RProvider/RInteropClient.fs
@@ -43,7 +43,17 @@ module internal RInteropClient =
                         System.AppDomain.CurrentDomain.GetAssemblies()
                         |> Seq.tryFind(
                             fun a-> System.Reflection.AssemblyName.ReferenceMatchesDefinition(fsharpCoreName, a.GetName()))
-                    let exePath = Path.Combine(Path.GetDirectoryName( Assembly.GetExecutingAssembly().Location), server)
+                            
+                    /// The location of the RProvider assembly.
+                    /// If the assembly has been shadow-copied, this will be the assembly's
+                    /// original location, not the shadow-copied location.
+                    let assem = Assembly.GetExecutingAssembly()
+                    let assemblyLocation =
+                        if System.AppDomain.CurrentDomain.ShadowCopyFiles then
+                            (new System.Uri (assem.EscapedCodeBase)).LocalPath
+                        else assem.Location
+                            
+                    let exePath = Path.Combine(Path.GetDirectoryName(assemblyLocation), server)
                     let arguments = channelName
                     let startInfo = ProcessStartInfo(UseShellExecute = false, CreateNoWindow = true, FileName=exePath, Arguments = arguments, WindowStyle = ProcessWindowStyle.Hidden)
                     let p = Process.Start(startInfo, EnableRaisingEvents = true)


### PR DESCRIPTION
This is a fix for #122
Always use original location instead of shadow-copied location when loading RProvider plugins.
@jack-pappas wrote the original fix, but didn't fix the RInteropClient, so I took his pull request and redid in for RInteropClient as well.

If I know how to add to jack's pull-req as myself, I would do that, instead I simply pulled his req and amended it.
