### PR TITLE
Make R provider work on Mac

### DIFF
--- a/src/RProvider/Program.fs
+++ b/src/RProvider/Program.fs
@@ -24,7 +24,6 @@ let startServer channelName tempFile =
 
   // Create an IPC channel that exposes RInteropServer instance
   let chan = new Ipc.IpcChannel(channelName)
-
   Logging.logf "Registering RInteropServer at channel '%s'" channelName
   ChannelServices.RegisterChannel(chan, false)
   let serviceEntry =
@@ -35,11 +34,15 @@ let startServer channelName tempFile =
   Logging.logf "Ready for connections.."
   File.Delete(tempFile)
 
+  // Get the parent PID - when the parent stops, we Stop the event loop
   let parentPid = channelName.Split('_').[1]
   let parentProcess = Process.GetProcessById(int parentPid)
   Logging.logf "Waiting for parent process pid=%d (%A)" (int parentPid) parentProcess
-  asyncWaitForExit (int parentPid) |> Async.RunSynchronously
-  Logging.logf "Closing"
+  async {
+    do! asyncWaitForExit (int parentPid)
+    Logging.logf "Posting Stop command"
+    EventLoop.queue.Add(Stop) } |> Async.Start 
+
 
 
 [<STAThreadAttribute>]
@@ -63,7 +66,13 @@ let main argv =
     if not (File.Exists(argv.[1])) then
       failwith "File passed as the second argument must exist!"
 
+    // Expose the server object via remoting
     startServer argv.[0] argv.[1]
+    Logging.logf "Server started, running event loop"
+
+    // Run Event Loop until the parent process stops
+    EventLoop.startEventLoop()
+    Logging.logf "Event loop finished, shutting down"
     0
   with e -> 
     Logging.logf "RProvider.Server' failed: %A" e

--- a/src/RProvider/RInterop.fs
+++ b/src/RProvider/RInterop.fs
@@ -291,7 +291,9 @@ module internal RInteropInternal =
     let eval (expr: string) = 
         Logging.logWithOutput characterDevice (fun () ->
             Logging.logf "eval(%s)" expr
-            engine.Value.Evaluate(expr) )
+            let res = engine.Value.Evaluate(expr) 
+            Logging.logf "eval(%s) returned %A" expr res
+            res )
 
     let evalTo (expr: string) (symbol: string) = 
         Logging.logWithOutput characterDevice (fun () ->

--- a/src/RProvider/RInteropServer.fs
+++ b/src/RProvider/RInteropServer.fs
@@ -8,50 +8,101 @@ open RProvider.RInterop
 open RProvider.Internal
 open System
 
+/// Event loop (see below) can either perform some work item or stop 
+type internal EventLoopMessage =
+  | Run of (unit -> unit)
+  | Stop
+
+/// The REngine can only be safely accessed from a single thread 
+/// and on Mac, this has to be the main thread of the application.
+///
+/// So, this application implements a simple event loop (running 
+/// once everything is setup) that picks REngine operations from a
+/// concurrent queue (the RInteropServer instance initialized via
+/// .NET remoting sends thigns here) and processes them.
+module internal EventLoop = 
+    let queue = new System.Collections.Concurrent.BlockingCollection<_>()
+
+    /// Start the event loop - this should be called 
+    let startEventLoop () = 
+        Logging.logf "server event loop: starting"
+        try
+          let initResultValue = RInit.initResult.Force()
+          let mutable running = true
+          while running do
+            match queue.Take() with
+            | Run f ->
+                Logging.logf "server event loop: got work item"
+                f()
+            | Stop -> 
+                Logging.logf "server event loop: got stop command"
+                running <- false
+        with e ->
+            Logging.logf "server event loop: failed with %A" e
+
+    /// Run a server command (that accesses REngine) safely in the event loop. 
+    /// This sends a command to the event loop & propagates exceptions      
+    let runServerCommandSafe f =
+        Logging.logf "Adding work item to queue"
+        use evt = new System.Threading.AutoResetEvent(false)
+        let result = ref (Choice1Of3())
+
+        // Add function with exception handling to the queue & wait for result
+        queue.Add(Run(fun () ->
+          try     
+            try
+              result := Choice2Of3(f())
+            with ex -> 
+              let ex = 
+                if ex.GetType().IsSerializable then ex
+                else Exception(ex.Message)
+              result := Choice3Of3(ex)
+          finally
+            evt.Set() |> ignore ))
+        evt.WaitOne() |> ignore
+        match result.Value with
+        | Choice1Of3() -> failwith "logic error: Item in the queue was not processed"
+        | Choice2Of3 res -> res
+        | Choice3Of3 ex -> raise ex
+
+
+/// Server object that is exposed via remoting and is called by the editor
+/// to get information about R (packages, functions, RData files etc.)
 type RInteropServer() =
     inherit MarshalByRefObject()
     
-    let initResultValue = RInit.initResult.Force()
-
-    let exceptionSafe f =
-        try
-            f()
-        with
-        | ex when ex.GetType().IsSerializable -> raise ex
-        | ex ->
-            failwith ex.Message
-
-    member x.RInitValue =
-        match initResultValue with
+    member x.RInitValue : string option =
+        // No need for event loop here, because this is initialized
+        // when the event loop starts (so initResult has value now)
+        match RInit.initResult.Value with
         | RInit.RInitError error -> Some error
         | _ -> None
-
+       
     member x.GetPackages() =
-        exceptionSafe <| fun () ->
-            getPackages()
+        EventLoop.runServerCommandSafe getPackages
 
     member x.LoadPackage(package) =
-        exceptionSafe <| fun () ->
+        EventLoop.runServerCommandSafe <| fun () ->
             loadPackage package
         
     member x.GetBindings(package) =
-        exceptionSafe <| fun () ->
+        EventLoop.runServerCommandSafe <| fun () ->
             getBindings package
         
     member x.GetFunctionDescriptions(package:string) =
-        exceptionSafe <| fun () ->
+        EventLoop.runServerCommandSafe <| fun () ->
             getFunctionDescriptions package
         
     member x.GetPackageDescription(package) =
-        exceptionSafe <| fun () ->
+        EventLoop.runServerCommandSafe <| fun () ->
             getPackageDescription package
         
     member x.MakeSafeName(name) =
-        exceptionSafe <| fun () ->
+        EventLoop.runServerCommandSafe <| fun () ->
             makeSafeName name
 
     member x.GetRDataSymbols(file) =
-        exceptionSafe <| fun () ->
+        EventLoop.runServerCommandSafe <| fun () ->
             let env = REnv(file) 
             [| for k in env.Keys ->
                   let v = env.Get(k)


### PR DESCRIPTION
Make R provider work on Mac

Currently, Xamarin studio runs as 32 bit process and R runs only as 64 bit
process, so to make this work, you have to compile 64 bit version of mono.
However, once that's done, this should work. There are two tricks:
- You need to create `~/.rprovider.conf` pointing to your 64 bit mono
  (the file should contain e.g. `MONO64=/usr/local/mono64/bin/mono`)
- You need to have R in PATH so that we can run `R --print-home` to 
  get R location.

The main changes are:
- In `RProvider.Server.exe` - this exposes the access to R via remoting.
  On Mono, this did not work giving the evil "C stack size exceeded" error.
  This is usually related to threading, so I changed this to access the R
  engine through a simple event loop running on the main thread (this is
  the only thing that worked on Mac) - this is for IntelliSense only and
  I think it is safer choice for Windows too. 
- In `RInteropClient.fs`, we need to find location of 64bit mono
  and if that fails, we report a nice error (through IntelliSense).
- In `RInit.fs`, I added a new approach to resolving R location, which
  is only used on Mac and calls `R --print-home`.
- Also, `RTypeBuilder.fs` returned a lazy enumerable from a function that
  was wrapped in a lock, which is obviously unintended, so I fixed that
  (afaik, it didn't cause any deadlocks, so this should be fine)

![Screenshot](https://pbs.twimg.com/media/B659pBPIAAACgrO.png)
