### PR TITLE
Workaround #140

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -92,13 +92,12 @@ Target "BuildTests" (fun _ ->
 )
 
 Target "MergeRProviderServer" (fun _ -> 
-  () (*
     let buildMergedDir = binDir @@ "merged"
     CreateDir buildMergedDir
 
     let toPack = 
         (binDir @@ "RProvider.Server.exe") + " " +
-        (binDir @@ "../tools/FSharp.Core.dll") + " " +
+        (binDir @@ "FSharp.Core.dll") + " " +
         (binDir @@ "RDotNet.FSharp.dll") + " " +
         (binDir @@ "RProvider.Runtime.dll")
 
@@ -116,7 +115,6 @@ Target "MergeRProviderServer" (fun _ ->
     !! (buildMergedDir @@ "*.*") 
     |> CopyFiles binDir
     DeleteDir buildMergedDir
-*)
 ) 
 
 // --------------------------------------------------------------------------------------

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,7 +8,7 @@ nuget R.NET.Community.FSharp 0.1.9
 nuget xunit.runners
 nuget FAKE
 nuget NuGet.CommandLine
-nuget ILRepack
+nuget ILRepack 1.22.2
 nuget FSharp.Core 3.0.2
 
 github fsprojects/FSharp.TypeProviders.StarterPack src/ProvidedTypes.fsi

--- a/paket.lock
+++ b/paket.lock
@@ -12,7 +12,7 @@ NUGET
       Zlib.Portable (>= 1.10.0)
     FSharp.Formatting (2.6.0)
       FSharp.Compiler.Service (>= 0.0.81)
-    ILRepack (1.25.0)
+    ILRepack (1.22.2)
     NuGet.CommandLine (2.8.3)
     R.NET.Community (1.5.16)
     R.NET.Community.FSharp (0.1.9)


### PR DESCRIPTION
As of today Cecil (used in ILRepack) fails to link generic parameters
in some (nested generics types+methods) scenarios.
A fix was attempting in later versions but it fails in other scenarios.
Version 1.22.2 is still the most stable one, and it manages to merge
your deps (didn't check further than the build success though).
