### PR TITLE
Fix docs generation and eliminate warnings

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -20,16 +20,8 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FSharp.Compiler.Service/lib/net40"
-#I "../../packages/FSharp.Formatting/lib/net40"
-#I "../../packages/RazorEngine/lib/net40/"
-#r "../../packages/Microsoft.AspNet.Razor/lib/net40/System.Web.Razor.dll"
+#load "../../packages/FSharp.Formatting/FSharp.Formatting.fsx"
 #r "../../packages/FAKE/tools/FakeLib.dll"
-#r "RazorEngine.dll"
-#r "FSharp.Literate.dll"
-#r "FSharp.Markdown.dll"
-#r "FSharp.CodeFormat.dll"
-#r "FSharp.MetadataFormat.dll"
 open Fake
 open System.IO
 open Fake.FileHelper

--- a/paket.lock
+++ b/paket.lock
@@ -28,6 +28,6 @@ NUGET
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.StarterPack
   specs:
-    src/DebugProvidedTypes.fs (70080986a4226e8218af09386cceb42e7a0ff00e)
-    src/ProvidedTypes.fs (70080986a4226e8218af09386cceb42e7a0ff00e)
-    src/ProvidedTypes.fsi (70080986a4226e8218af09386cceb42e7a0ff00e)
+    src/DebugProvidedTypes.fs (c098da43ef99c9f15f7ed7ec4726dace9b95ad06)
+    src/ProvidedTypes.fs (c098da43ef99c9f15f7ed7ec4726dace9b95ad06)
+    src/ProvidedTypes.fsi (c098da43ef99c9f15f7ed7ec4726dace9b95ad06)

--- a/tests/Test.RProvider/Test.RProvider.fsproj
+++ b/tests/Test.RProvider/Test.RProvider.fsproj
@@ -12,7 +12,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>Test.RProvider</Name>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Test.RProvider/app.config
+++ b/tests/Test.RProvider/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="RazorEngine" publicKeyToken="9ee697374c7e744a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.1.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
There ware two build warning - this PR fixes those:
- One was incomplete pattern matching in Type Provider starter pack (I fixed it there)
- Another was FSharp.Core mismatch (FsCheck now uses 4.3.1.0), updated version in tests
