### PR TITLE
Skip assembly resolution for mscorlib.resources

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,3 +24,4 @@
 * 1.1.9 - Update to R.NET 1.6.3
 * 1.1.10 - Update NuGet package to depend on R.NET 1.6.3
 * 1.1.11 - Update to R.NET 1.6.4 (support R version 2.14.1)
+* 1.1.12 - Skip assembly resolution for mscorlib.resources (avoids recursive lookup error)

--- a/paket.lock
+++ b/paket.lock
@@ -2,21 +2,21 @@ NUGET
   remote: https://www.nuget.org/api/v2
   specs:
     DynamicInterop (0.7.4)
-    FAKE (3.35.0)
+    FAKE (3.36.0)
     FsCheck (1.0.4)
     FsCheck.Xunit (1.0.4)
       FsCheck (>= 1.0.4)
       xunit (>= 1.9.2)
-    FSharp.Compiler.Service (0.0.89)
+    FSharp.Compiler.Service (1.3.1.0)
     FSharp.Core (3.0.2)
-    FSharp.Data (2.2.2)
+    FSharp.Data (2.2.5)
       Zlib.Portable (>= 1.10.0) - framework: portable-net40+sl50+wp80+win80
-    FSharp.Formatting (2.9.7)
+    FSharp.Formatting (2.9.10)
       FSharp.Compiler.Service (>= 0.0.87)
       FSharpVSPowerTools.Core (1.8.0)
     FSharpVSPowerTools.Core (1.8.0)
       FSharp.Compiler.Service (>= 0.0.87)
-    ILRepack (2.0.0)
+    ILRepack (2.0.2)
     NuGet.CommandLine (2.8.5)
     R.NET.Community (1.6.4)
       DynamicInterop (0.7.4)
@@ -24,7 +24,7 @@ NUGET
       R.NET.Community (>= 1.6.4)
     xunit (1.9.2)
     xunit.runners (1.9.2)
-    Zlib.Portable (1.10.0) - framework: portable-net40+sl50+wp80+win80
+    Zlib.Portable (1.11.0) - framework: portable-net40+sl50+wp80+win80
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.StarterPack
   specs:

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -5,7 +5,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("BlueMountain Capital")>]
 [<assembly: AssemblyProductAttribute("RProvider")>]
 [<assembly: AssemblyDescriptionAttribute("An F# Type Provider providing strongly typed access to the R statistical package.")>]
-[<assembly: AssemblyVersionAttribute("1.1.12")>]
-[<assembly: AssemblyFileVersionAttribute("1.1.12")>]
+[<assembly: AssemblyVersionAttribute("1.1.13")>]
+[<assembly: AssemblyFileVersionAttribute("1.1.13")>]
 do ()
 

--- a/src/RProvider/Configuration.fs
+++ b/src/RProvider/Configuration.fs
@@ -57,7 +57,11 @@ let getProbingLocations() =
 let resolveReferencedAssembly (asmName:string) = 
   
   // Do not interfere with loading FSharp.Core resources, see #97
-  if asmName.StartsWith "FSharp.Core.resources" then null else
+  // This also breaks for "mscorlib.resources" and so it might be good idea to skip all 
+  // resources (both short format "foo.resources" and long format "foo.resources, Version=4.0.0.0...")
+  if asmName.EndsWith ".resources" || asmName.Contains ".resources," then 
+    (* Do not log when we skip, because that would cause recursive lookup for mscorlib.resources *) null else
+  Logging.logf "Attempting resolution for '%s'" asmName
 
   // First, try to find the assembly in the currently loaded assemblies
   let fullName = AssemblyName(asmName)


### PR DESCRIPTION
I was getting the error #97 again, but this time the recursive loop was triggered by a lookup for `mscorlib.resources`. This PR changes the code so that it skips all "resource" assemblies. 
