### PR TITLE
Allow specifying of R path in .rprovider.conf (fix #165)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,3 +30,4 @@
 * 1.1.15 - Disable R.NET AutoPrint (fix #161 and perhaps #160)
 * 1.1.16-alpha - Load correct dependencies in RProvider.fsx (fix #166)
 * 1.1.17 - Fix RProvider.fsx (#166), Mac loading and update dependenices
+* 1.1.18-alpha - Allow specifying of R path in .rprovider.conf (fix #165)

--- a/src/RProvider.DesignTime/RInteropClient.fs
+++ b/src/RProvider.DesignTime/RInteropClient.fs
@@ -35,18 +35,10 @@ let newChannelName() =
 /// On Mac and Linux, we need to run the server using 64 bit version of mono
 /// There is no standard location for this, so the user needs ~/.rprovider.conf 
 let get64bitMonoExecutable() = 
-    if Environment.OSVersion.Platform = PlatformID.Unix ||
-       Environment.OSVersion.Platform = PlatformID.MacOSX then
-        try
-            let home = Environment.GetEnvironmentVariable("HOME")
-            Logging.logf "get64bitMonoExecutable - Home: '%s'" home
-            let config = home + "/.rprovider.conf"
-            IO.File.ReadLines(config) 
-            |> Seq.pick (fun line ->
-                match line.Split('=') with
-                | [| "MONO64"; exe |] -> Some exe
-                | _ -> None )
-        with e -> raise (RInitializationError("Mono 64bit executable not set (~/.rprovider.conf missing or invalid)"))
+    if Configuration.isUnixOrMac() then
+        match Configuration.getRProviderConfValue "MONO64" with
+        | Some exe -> exe
+        | None -> raise (RInitializationError("Mono 64bit executable not set (~/.rprovider.conf missing or invalid)"))
     else "mono" // On non-*nix systems, we *try* running just mono
 
 // Global variables for remembering the current server


### PR DESCRIPTION
On El Capitan, we cannot just run `R --print-home` because El Capitan does not pass PATH to stand-alone applications not started from command line.

I'm asking @evelinag for help here, because she has some update on installing 64 bit mono too.
