### PR TITLE
Fix for issue #199

### DIFF
--- a/nuget/RProvider.Runtime.dll.config
+++ b/nuget/RProvider.Runtime.dll.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="ProbingLocations" value="../../../*/lib/net40" />
+    <add key="ProbingLocations" value="../../../../*/*/lib/net40;../../../../*/*/lib/netstandard1.2" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
Change ProbingLocations to work with both SDK-style projects and versions of DynamicInterop which target netstandard