### PR TITLE
Add probing locations to locate latest Deedle and RPlugin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+* 1.1.22 - Add ProbingLocations for latest Deedle.RPlugin
 * 1.1.21 - Fix ProbingLocations (#199)
 * 1.1.20 - Cross-platform improvements
 * 1.1.19-alpha - Fix FSharp.Core.dll included in the package

--- a/nuget/RProvider.Runtime.dll.config
+++ b/nuget/RProvider.Runtime.dll.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="ProbingLocations" value="../../../../*/*/lib/net40;../../../../*/*/lib/netstandard1.2" />
+    <add key="ProbingLocations" value="../../../../*/*/lib/net40;../../../../*/*/lib/netstandard1.2;../../../../*/*/lib/net45;../../../../*/*/lib/net451" />
   </appSettings>
 </configuration>

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyCompanyAttribute("BlueMountain Capital, FsLab")>]
 [<assembly: AssemblyProductAttribute("RProvider")>]
 [<assembly: AssemblyDescriptionAttribute("An F# Type Provider providing strongly typed access to the R statistical package.")>]
-[<assembly: AssemblyVersionAttribute("1.1.21")>]
-[<assembly: AssemblyFileVersionAttribute("1.1.21")>]
+[<assembly: AssemblyVersionAttribute("1.1.22")>]
+[<assembly: AssemblyFileVersionAttribute("1.1.22")>]
 do ()
 

--- a/src/RProvider.DesignTime/RProvider.DesignTime.fsproj
+++ b/src/RProvider.DesignTime/RProvider.DesignTime.fsproj
@@ -112,6 +112,17 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
         <Reference Include="RDotNet">
           <HintPath>..\..\packages\R.NET\lib\net40\RDotNet.dll</HintPath>
           <Private>True</Private>

--- a/src/RProvider.DesignTime/paket.references
+++ b/src/RProvider.DesignTime/paket.references
@@ -3,3 +3,4 @@ File:ProvidedTypes.fs
 
 R.NET.Community
 R.NET.Community.FSharp
+FSharp.Core

--- a/src/RProvider/RProvider.Runtime.fsproj
+++ b/src/RProvider/RProvider.Runtime.fsproj
@@ -104,6 +104,17 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
         <Reference Include="RDotNet">
           <HintPath>..\..\packages\R.NET\lib\net40\RDotNet.dll</HintPath>
           <Private>True</Private>

--- a/src/RProvider/RProvider.Server.fsproj
+++ b/src/RProvider/RProvider.Server.fsproj
@@ -112,6 +112,17 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
         <Reference Include="RDotNet">
           <HintPath>..\..\packages\R.NET\lib\net40\RDotNet.dll</HintPath>
           <Private>True</Private>

--- a/src/RProvider/RProvider.fsproj
+++ b/src/RProvider/RProvider.fsproj
@@ -110,6 +110,17 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
         <Reference Include="RDotNet">
           <HintPath>..\..\packages\R.NET\lib\net40\RDotNet.dll</HintPath>
           <Private>True</Private>

--- a/src/RProvider/paket.references
+++ b/src/RProvider/paket.references
@@ -1,2 +1,3 @@
 R.NET.Community
 R.NET.Community.FSharp
+FSharp.Core

--- a/src/RWrapperGenerator/RWrapperGenerator.fsproj
+++ b/src/RWrapperGenerator/RWrapperGenerator.fsproj
@@ -122,6 +122,17 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
       <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\..\packages\FSharp.Core\lib\net45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2')">
+      <ItemGroup>
         <Reference Include="RDotNet">
           <HintPath>..\..\packages\R.NET\lib\net40\RDotNet.dll</HintPath>
           <Private>True</Private>

--- a/src/RWrapperGenerator/paket.references
+++ b/src/RWrapperGenerator/paket.references
@@ -3,3 +3,4 @@ File:ProvidedTypes.fs
 
 R.NET.Community
 R.NET.Community.FSharp
+FSharp.Core

--- a/tests/Test.RProvider/paket.references
+++ b/tests/Test.RProvider/paket.references
@@ -3,3 +3,4 @@ FsCheck.Xunit
 R.NET.Community
 xunit
 xunit.runners
+FSharp.Core


### PR DESCRIPTION
Deedle 2.0.0 is built for framework 4.5 and Deedle.RPlugin is built on framework 4.5.1. Add net45 and net451 location in RProvider.Runtime.dll.config. See old comments in https://github.com/fslaborg/RProvider/pull/81