### PR TITLE
Re-add license to nuget packages

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -43,6 +43,7 @@ let projectDescription = """
 let authors = "BlueMountain Capital;FsLab"
 let companyName = "BlueMountain Capital, FsLab"
 let tags = "F# fsharp R TypeProvider visualization statistics"
+let license = "BSD-2-Clause"
 
 let packageProjectUrl = "https://fslaborg.org/RProvider/"
 let repositoryType = "git"
@@ -114,7 +115,6 @@ Target.create "RunTests" (fun _ ->
 
 Target.create "NuGet" (fun _ ->
     // Format the description to fit on a single line (remove \r\n and double-spaces)
-    let specificVersion (name, version) = name, sprintf "[%s]" version
     let projectDescription = projectDescription.Replace("\r", "").Replace("\n", "").Replace("  ", " ")
     
     // Format the release notes
@@ -127,14 +127,14 @@ Target.create "NuGet" (fun _ ->
         ("PackageTags", tags)
         ("RepositoryType", repositoryType)
         ("RepositoryUrl", repositoryUrl)
-        //("PackageLicenseExpression", license) // TODO Enable license after stop packing PipeMethodCalls
+        ("PackageLicenseExpression", license)
         ("PackageReleaseNotes", releaseNotes)
         ("Summary", projectSummary)
         ("PackageDescription", projectDescription)
         ("EnableSourceLink", "true")
         ("PublishRepositoryUrl", "true")
         ("EmbedUntrackedSources", "true")
-        //("IncludeSymbols", "true") //TODO Enable symbols
+        ("IncludeSymbols", "true")
         ("IncludeSymbols", "false")
         ("SymbolPackageFormat", "snupkg")
     ]


### PR DESCRIPTION
## Proposed Changes

The nuget package was missing it's license information. I have changed the FAKE build script to add this back in. I also added symbols back in, which got lost in the 2.0 transition.

## Types of changes

What types of changes does your code introduce to RProvider?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
