### PR TITLE
Re-enable Ubuntu CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,14 +12,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest,windows-latest]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
     env:
       RPROVIDER_LOG: rlog.txt
 
     steps:
     - uses: actions/checkout@master
+    - name: Setup R - Ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      run:   |
+          sudo apt update -qq
+          sudo apt install --no-install-recommends software-properties-common dirmngr
+          wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+          sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+          sudo apt install --no-install-recommends r-base
     - uses: r-lib/actions/setup-r@v1
-      name: Setup R environment
+      name: Setup R - Windows / macOS
+      if: matrix.os != 'ubuntu-latest'
       with:
           r-version: '4.0.2'
     - name: Set R_HOME environment variable

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,6 +49,7 @@ jobs:
         include-prerelease: true
     - name: test of RProvider nuget package
       run: dotnet fsi citest.fsx
+      timeout-minutes: 2 # Times out after 1 minute
     - name: Check RProvider log
       if: ${{ always() }}
       run: cat rlog.txt

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Push to master
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, test-ci-ubuntu ]
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest,windows-latest]
+        os: [macos-latest,windows-latest,ubuntu-18.04,ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,17 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-      run:   |
-         if [ "$RUNNER_OS" == "Linux" ]; then
-              echo "R_HOME=$(R RHOME)" >> "$GITHUB_ENV"
-         elif [ "$RUNNER_OS" == "macOS" ]; then
-              echo "R_HOME=$(R RHOME)" >> "$GITHUB_ENV"
-         elif [ "$RUNNER_OS" == "Windows" ]; then
-              echo "R_HOME=$(R RHOME)" >> "$GITHUB_ENV"
-         else
-              echo "$RUNNER_OS not supported"
-              exit 1
-         fi
     - name: Setup R for Ubuntu
       run:   |
           sudo apt update -qq

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,10 +17,28 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - uses: r-lib/actions/setup-r@v1
-      name: Setup R environment
-      with:
-          r-version: '4.0.2'
+      run:   |
+         if [ "$RUNNER_OS" == "Linux" ]; then
+              echo "R_HOME=$(R RHOME)" >> "$GITHUB_ENV"
+         elif [ "$RUNNER_OS" == "macOS" ]; then
+              echo "R_HOME=$(R RHOME)" >> "$GITHUB_ENV"
+         elif [ "$RUNNER_OS" == "Windows" ]; then
+              echo "R_HOME=$(R RHOME)" >> "$GITHUB_ENV"
+         else
+              echo "$RUNNER_OS not supported"
+              exit 1
+         fi
+    - name: Setup R for Ubuntu
+      run:   |
+          sudo apt update -qq
+          sudo apt install --no-install-recommends software-properties-common dirmngr
+          wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+          sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+          sudo apt install --no-install-recommends r-base
+    # - uses: r-lib/actions/setup-r@v1
+    #   name: Setup R environment
+    #   with:
+    #       r-version: '4.0.2'
     - name: Set R_HOME environment variable
       run:   |
          if [ "$RUNNER_OS" == "Linux" ]; then

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04,ubuntu-20.04]
     env:
-      RPROVIDER_LOG: /var/log/rprovider.log
+      RPROVIDER_LOG: /home/runner/rprovider.log
 
     steps:
     - uses: actions/checkout@master
@@ -52,7 +52,7 @@ jobs:
       timeout-minutes: 2 # Times out after 1 minute
     - name: Check RProvider log
       if: ${{ always() }}
-      run: cat /var/log/rprovider.log
+      run: cat /home/runner/rprovider.log
     - name: Restore tool dependencies
       run: dotnet tool restore
     - name: Restore paket dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest,windows-latest,ubuntu-18.04,ubuntu-20.04]
+        os: [ubuntu-18.04,ubuntu-20.04]
     env:
-      RPROVIDER_LOG: rlog.txt
+      RPROVIDER_LOG: /var/log/rprovider.log
 
     steps:
     - uses: actions/checkout@master
@@ -52,7 +52,7 @@ jobs:
       timeout-minutes: 2 # Times out after 1 minute
     - name: Check RProvider log
       if: ${{ always() }}
-      run: cat rlog.txt
+      run: cat /var/log/rprovider.log
     - name: Restore tool dependencies
       run: dotnet tool restore
     - name: Restore paket dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest,windows-latest,ubuntu-18.04,ubuntu-20.04]
+    env:
+      RPROVIDER_LOG: rlog.txt
 
     steps:
     - uses: actions/checkout@master
@@ -45,6 +47,11 @@ jobs:
       with:
         dotnet-version: '6.0.x'
         include-prerelease: true
+    - name: test of RProvider nuget package
+      run: dotnet fsi citest.fsx
+    - name: Check RProvider log
+      if: ${{ always() }}
+      run: cat rlog.txt
     - name: Restore tool dependencies
       run: dotnet tool restore
     - name: Restore paket dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,7 @@ name: Push to master
 
 on:
   push:
-    branches: [ master, test-ci-ubuntu ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,23 +11,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04,ubuntu-20.04]
-    env:
-      RPROVIDER_LOG: /home/runner/rprovider.log
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
     - uses: actions/checkout@master
-    - name: Setup R for Ubuntu
+    - name: Setup R - Ubuntu
+      if: matrix.os == 'ubuntu-latest'
       run:   |
           sudo apt update -qq
           sudo apt install --no-install-recommends software-properties-common dirmngr
           wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
           sudo add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
           sudo apt install --no-install-recommends r-base
-    # - uses: r-lib/actions/setup-r@v1
-    #   name: Setup R environment
-    #   with:
-    #       r-version: '4.0.2'
+    - uses: r-lib/actions/setup-r@v1
+      name: Setup R - Windows / macOS
+      if: matrix.os != 'ubuntu-latest'
+      with:
+          r-version: '4.0.2'
     - name: Set R_HOME environment variable
       run:   |
          if [ "$RUNNER_OS" == "Linux" ]; then
@@ -54,19 +54,13 @@ jobs:
       with:
         dotnet-version: '6.0.x'
         include-prerelease: true
-    - name: test of RProvider nuget package
-      run: dotnet fsi citest.fsx
-      timeout-minutes: 2 # Times out after 1 minute
-    - name: Check RProvider log
-      if: ${{ always() }}
-      run: cat /home/runner/rprovider.log
     - name: Restore tool dependencies
       run: dotnet tool restore
     - name: Restore paket dependencies
       run: dotnet paket restore
     - name: Restore dependencies
       run: dotnet restore RProvider.sln
-    - name: Restore dependencies
+    - name: Restore dependencies (tests)
       run: dotnet restore RProvider.Tests.sln
     - name: Build
       run: dotnet fake build -t All
@@ -77,8 +71,6 @@ jobs:
         publish_dir: ./output
         publish_branch: gh-pages
         force_orphan: true
-    - name: Examine bin
-      run: ls -r bin
     - name: Publish NuGets (if this version not published before)
       if: matrix.os == 'windows-latest'
       run: dotnet nuget push bin\*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETKEY }} --skip-duplicate

--- a/citest.fsx
+++ b/citest.fsx
@@ -1,0 +1,6 @@
+#r "nuget:RProvider,2.0.1-beta3"
+
+open RProvider
+open RProvider.``base``
+
+R.c(1.,2.,3)


### PR DESCRIPTION
## Proposed Changes

I debugged and found the issue with Ubuntu on Github Actions. The installer action was causing the Rprovider test project to build infinitely, as R.NET was hanging on the creation of an engine instance. Normal Ubuntu package installs work fine - tested locally and on WSL with R 3.5 and 4.1. Changed the github actions to use a standard install procedure for R rather than the r action - addresses #238 


## Types of changes

What types of changes does your code introduce to RProvider?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
