### PR TITLE
Replace "." with "_" in package names

### DIFF
--- a/src/RProvider.DesignTime/RTypeBuilder.fs
+++ b/src/RProvider.DesignTime/RTypeBuilder.fs
@@ -17,7 +17,7 @@ module internal RTypeBuilder =
         Logging.logf "generateTypes: getting packages"
         let packages = 
           [ yield "base", ns
-            for package in server.InvokeAsync(fun s -> s.GetPackages()) |> Async.AwaitTask |> Async.RunSynchronously do yield package, ns + "." + package ]
+            for package in server.InvokeAsync(fun s -> s.GetPackages()) |> Async.AwaitTask |> Async.RunSynchronously do yield package, ns + "." + makeSafeName package ]
         for package, pns in packages do
             let pty = ProvidedTypeDefinition(asm, pns, "R", Some(typeof<obj>))    
 


### PR DESCRIPTION
## Proposed Changes

Fixes #226. Specifically, in packages like `data.table` the package name should have an underscore rather than a period for consistency. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Technically a breaking change but given 2.0 is just released I think it is reasonable to include.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

With the new functionality intellisense on `open` statements works as one would expect when trying to find `data.table` (before the change it would show `data` only, see the raised issue):

![image](https://user-images.githubusercontent.com/5226115/139856029-4eb4ed83-5893-4995-bda2-4bf52799796d.png)


Here's output from interactive:

```fsharp
open RDotNet
open RProvider
open RProvider.data_table

let flights = R.fread("https://raw.githubusercontent.com/Rdatatable/data.table/master/vignettes/flights14.csv")

let names = R.names(flights).AsCharacter() |> Seq.toList

[ for nm in names[..3] -> 
    nm, flights.AsDataFrame()[nm] |> Seq.take 3 ]
|> List.iter (printfn "%A")    
```
```
("year", seq [2014; 2014; 2014])
("month", seq [1; 1; 1])
("day", seq [1; 1; 1])
("dep_delay", seq [14; -3; 2])
val flights: RDotNet.SymbolicExpression
val names: string list =
  ["year"; "month"; "day"; "dep_delay"; "arr_delay"; "carrier"; "origin";
   "dest"; "air_time"; "distance"; "hour"]
val it: unit = ()
```